### PR TITLE
S27: /init and /clear (light commands)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository is the standalone home of those packages. They were extracted fr
 - **Overlays** — four-option approval panel (with session-level "always allow" inheritance) and tabbed user-questionnaire overlays.
 - **Two-row status footer** — model name (priority 0), the session-mode badge `plan`/`yolo` (priority 2, hidden in normal mode), git branch (priority 10), context occupancy `ctx N` (priority 20); entries are registry contributions, not hardcoded. Shift+Tab cycles the session mode normal → plan → yolo (`/yolo` auto-approves tool calls, questions still pop).
 - **Bottom dock panes** — activity spinner while the agent runs, queued inbox messages with Up-to-recall, todo list with the Ctrl-T collapse toggle, and a `/btw` side-question pane that forks the live session.
-- **Slash commands** — `/quit` `/new` `/fork` `/sessions` (`/resume` is its alias) `/help` `/theme` `/btw` `/model` `/effort` `/provider` `/yolo`, all auto-listed in the editor's completion menu.
+- **Slash commands** — `/quit` `/new` (`/clear` is its alias) `/fork` `/sessions` (`/resume` is its alias) `/help` `/theme` `/btw` `/model` `/effort` `/provider` `/yolo` `/init`, all auto-listed in the editor's completion menu.
 - **Theming** — `/theme` hot-switching across `dark` / `light` / `auto` (OSC 11 background detection) / `custom` (JSON palette).
 
 ## Design philosophy

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@ Blue 是 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)（`
 - **Overlay** —— 四选项审批面板（session 级"总是允许"继承）与 tab 化用户问卷 overlay。
 - **两行状态栏** —— 模型名（priority 0）、会话模式徽标 `plan`/`yolo`（priority 2，normal 态隐藏）、git 分支（priority 10）、上下文占用 `ctx N`（priority 20）；条目是注册表贡献，不是写死的。Shift+Tab 循环会话模式 normal → plan → yolo（`/yolo` 自动放行工具审批，提问照常弹）。
 - **底部 dock 面板** —— agent 运行中的活动 spinner、排队消息（空编辑器上键召回）、todo 列表（Ctrl-T 折叠开关）、fork 当前会话的 `/btw` 旁路问答面板。
-- **Slash 命令** —— `/quit` `/new` `/fork` `/sessions`（`/resume` 为其别名）`/help` `/theme` `/btw` `/model` `/effort` `/provider` `/yolo`，全部自动进入编辑器补全菜单。
+- **Slash 命令** —— `/quit` `/new`（`/clear` 为其别名）`/fork` `/sessions`（`/resume` 为其别名）`/help` `/theme` `/btw` `/model` `/effort` `/provider` `/yolo` `/init`，全部自动进入编辑器补全菜单。
 - **主题** —— `/theme` 热切换：`dark` / `light` / `auto`（OSC 11 背景探测）/ `custom`（JSON 调色板）。
 
 ## 设计哲学

--- a/docs/blue-commands-plan.md
+++ b/docs/blue-commands-plan.md
@@ -51,7 +51,7 @@ p1-design §4.3 是本文档的前身（MVP 后命令面调研）。本次逐符
 | 命令 | kimi | pi | CC | Codex | Blue 现状/去向 |
 |---|---|---|---|---|---|
 | `/new` (`clear` 别名) | ✅ | ✅ | ✅ | ✅ | ✅ 已发货（commands-plugin.ts，`blue/request-new`） |
-| `/clear` | 别名 | — | 别名 | ✅ | **S27** 别名注册（command-meta 层） |
+| `/clear` | 别名 | — | 别名 | ✅ | ✅ 已发货（S27' 落地 2026-08-21：`registerCommandAliases('new', ['clear'])` 一行别名——补全下拉别名标注（`/new (clear)`）+ 提交重写 canonical，语义 = /new，§2.12） |
 | `/resume` | 别名 `/sessions` | ✅ | ✅ | ✅ | ✅ 已发货——2026-08-21 S24a dogfood 裁决：/resume 与 /sessions 本是一条命令，注册并入 `/sessions [<id>]`（无参开 picker、带参直发 `blue/request-resume`），/resume 走 command-meta 别名重写 |
 | `/sessions` | ✅ | ✅ | — | — | ✅ 已发货（picker overlay，D30 挂载） |
 | `/fork` | ✅ | ✅ | ✅ | — | ✅ 已发货（idle 守卫，`blue/request-fork`） |
@@ -118,7 +118,7 @@ p1-design §4.3 是本文档的前身（MVP 后命令面调研）。本次逐符
 | `/settings` (`config`) | ✅ | ✅ | `/config` | — | **S28** 待建（Blue 自有命名空间可写，harness 命名空间只读列出，⚠️） |
 | `/theme` | ✅ | — | ✅ | — | ✅ 已发货（theme-switch.ts） |
 | `/editor` | ✅ | — | — | — | 🚫 外部编辑器 Ctrl-G 未实现（roadmap P2 挂起） |
-| `/injections`（原拟 `/context`，注入显隐） | — | — | ✅ | — | **S27'** 待建（注入上下文显隐开关，D28/S19 语义反向——原拟名 `/context` 已被 S25 的上下文占用面板占用，**2026-08-21 定名 `/injections`**：fold.ts `source.kind !== 'user'` 分拣改可开关 + dsh-settings 'blue' 命名空间持久；开关只影响此后事件呈现、历史不回补——首个 blue 命名空间 settings 条目，为 S28 /settings 提供消费面） |
+| `/injections`（原拟 `/context`，注入显隐） | — | — | ✅ | — | 🚫 不做（**2026-08-21 用户裁决**：注入上下文维持 D28/S19 默认隐藏，不开显隐开关——原 S27' 范围项撤销，roadmap「预览版后挂起区」有条目；真实需求出现再议） |
 | `/add-dir` | ✅ | — | ✅ | — | 🚫 会话 cwd 无附加目录原语（roadmap 层无 surface） |
 | `/vim` | — | — | ✅ | ✅ | 🚫 需编辑器 provider 实现（P3 缝槽，rc.7 无） |
 | `/color` | — | — | ✅ | — | 🚫 主题契约已覆盖 |
@@ -134,7 +134,7 @@ p1-design §4.3 是本文档的前身（MVP 后命令面调研）。本次逐符
 | `/hooks` | — | — | ✅ | ✅ | 🚫 命令不做；上游现成 hooks 兼容桥（dsh-hooks-claude-code / hooks-codex 方言，rc.5 未随 rc.6 发布，§3.2） |
 | `/tools` | ✅ | — | — | — | **S28** 待建（⚠️ interim：fold request/header.tools；真枚举需 §7 #8） |
 | `/tasks` (`task`) | ✅ | — | ✅ | ✅ | **S28** 待建（⚠️ Adapt：todo 面板 + jobs 视图；ctx.jobs + tool-jobs 现成，§3.2） |
-| `/init` | ✅ | — | ✅ | ✅ | **S27** 待建（罐头提示 followup 生成 AGENTS.md） |
+| `/init` | ✅ | — | ✅ | ✅ | ✅ 已发货（S27' 落地 2026-08-21：`interaction/src/session-init.ts` 罐头提示 followup 写 AGENTS.md + idle 守卫拒绝并发） |
 | `/login` / `/logout` | ✅ | ✅ | ✅ | — | 🚫 认证面由 harness settings/凭据承担 |
 | `/doctor` | — | — | ✅ | ✅ | 🚫 与 /debug 合并（做一不做二） |
 | `/debug` | — | — | ✅ | — | 🚫 需诊断导出面（⛔ 顺延，随 §7 #10 后的诊断缝） |
@@ -153,13 +153,13 @@ p1-design §4.3 是本文档的前身（MVP 后命令面调研）。本次逐符
 | `/teleport` / `/remote-control` / `/ide` | CC/Codex | 远程/桌面 surface 不存在 |
 | `/import` (CC/Codex 语义) | CC/Codex | 配置迁移面（pi 的 JSONL /import 在 §2.3 已单列） |
 
-### 2.9 Blue 已发货命令映射（14 条）
+### 2.9 Blue 已发货命令映射（15 条）
 
 | 命令 | 各家同义 | Blue 注册位置 | 落地 |
 |---|---|---|---|
 | `/quit`（别名 `/q` `/exit`） | kimi/pi/CC/Codex `exit`/`quit`/`q` | `packages/interaction/src/commands-plugin.ts` → `ctx.get('appExit')(0)` | ✅ S6（别名 ✅ 2026-08-20，§2.12 首例） |
 | `/sessions [<id>]`（别名 `/resume`） | 四家 | `commands-plugin.ts`（带参直发 `'blue/request-resume'`，无参走 picker；2026-08-21 并入） | ✅ S6 · S24a |
-| `/new` | kimi `clear`、CC `clear`/`reset` | `commands-plugin.ts` → `'blue/request-new'` | ✅ S6 |
+| `/new`（别名 `/clear`） | kimi `clear`、CC `clear`/`reset` | `commands-plugin.ts` → `'blue/request-new'`（别名 S27' 2026-08-21） | ✅ S6 |
 | `/fork` | kimi/pi/CC | `commands-plugin.ts` → `'blue/request-fork'`（idle 守卫） | ✅ S6 |
 | `/sessions` | kimi `sessions`、pi `resume` | `commands-plugin.ts` → `sessionPersistence.list` picker（D30 editor-slot 替换） | ✅ S6 |
 | `/help` | kimi `help`/`h`/`?`、CC/Codex | `commands-plugin.ts` → `HelpOverlay`（commands + keys 双列） | ✅ S6 |
@@ -171,6 +171,7 @@ p1-design §4.3 是本文档的前身（MVP 后命令面调研）。本次逐符
 | `/status` | kimi/CC/Codex | `packages/interaction/src/session-commands.ts`（`InfoPanel` 两列只读面板：`info-panel.ts`；数字读 `usage.ts` 薄层） | ✅ S25（2026-08-21） |
 | `/context`（kimi `/usage` 同款） | kimi/CC | `session-commands.ts`（同 `InfoPanel`；tokenUsage/contextPressure 投影 + `assistant/*` 折回退） | ✅ S25（2026-08-21，落地后用户裁决由 /usage 更名） |
 | `/version` | kimi | `session-commands.ts` → notice（`BLUE_VERSION` + harness rc 行 + 当前模型） | ✅ S25（2026-08-21） |
+| `/init` | kimi/CC/Codex | `packages/interaction/src/session-init.ts`（罐头提示 followup + idle 守卫） | ✅ S27'（2026-08-21） |
 
 ### 2.10 上游插件自带命令（6 条，随 base 组合自动注册，Blue 零实现）
 
@@ -200,14 +201,14 @@ p1-design §4.3 是本文档的前身（MVP 后命令面调研）。本次逐符
 | 参数幽灵提示 | `/alias ` 经 `canonicalOf` 解析到 canonical 的 `input.hint`（与执行重写同一解析） |
 | 冲突 | 别名被其它 canonical 占用 → 启动期 fail-loud；alias 等于自身 canonical → 拒绝；同 canonical 重注册 = last-wins 替换（disposer 分代，旧 fiber 的 disposer 不清新注册） |
 
-**首例**：`/quit` 别名 `q`、`exit`（commands-plugin.ts 注册 `registerCommandAliases('quit', ['q', 'exit'])`）。计划内第二消费者：S27 `/clear` = `/new` 别名（§4.2，`registerCommandAliases('new', ['clear'])`，无需真实注册）。上游缝 #9（`CommandDefinition.aliases`）落地后本层可退化为声明式（§4.1 第 4 条修正注记）。
+**首例**：`/quit` 别名 `q`、`exit`（commands-plugin.ts 注册 `registerCommandAliases('quit', ['q', 'exit'])`）。第二消费者已落地：S27' `/clear` = `/new` 别名（§4.2，2026-08-21，`registerCommandAliases('new', ['clear'])`，无真实注册——补全下拉别名标注 + 执行语义等同 /new 均有 e2e）。上游缝 #9（`CommandDefinition.aliases`）落地后本层可退化为声明式（§4.1 第 4 条修正注记）。
 
 ### 2.11 kimi registry 元数据字段 vs dsh-commands rc.7
 
 kimi `KimiSlashCommand`（`apps/kimi-code/src/tui/commands/types.ts`）声明的元数据：`argumentHint`（补全行内提示）、`completeArgs(prefix)`（参数补全器）、`availability: 'always' | 'idle-only' | fn`（流式期间可用性）、`experimentalFlag`（实验门控隐藏）、`aliases`。dsh-commands rc.7 `CommandDefinition`（`dsh-commands/lib/index.js` `normalizeDefinition`）仅有 `name/description/input?/recordInput?/handler`，**无元数据字段**。差距与 Blue 侧落点：
 
 - `input.hint` 已有（`/resume` 已用）→ 补全行内提示 ✅ 现成
-- `aliases` → Blue 侧 `command-meta.ts` 注册表（✅ 已落地 2026-08-20，机制与消费见 §2.12；S27 `/clear` 消费）；上游 nice-to-have 缝（§7 #9）维持
+- `aliases` → Blue 侧 `command-meta.ts` 注册表（✅ 已落地 2026-08-20，机制与消费见 §2.12；S27' `/clear` 已消费 2026-08-21）；上游 nice-to-have 缝（§7 #9）维持
 - `availability` → Blue 侧 handler 内 idle 守卫（/fork 先例），不做声明式
 - `argumentHint` 幽灵提示 → S14 已实现 `setGhostHint` + `computeArgumentHint`，新命令参数提示走该链路
 
@@ -295,9 +296,9 @@ kimi `KimiSlashCommand`（`apps/kimi-code/src/tui/commands/types.ts`）声明的
 | `/version` | kimi | — | BLUE_VERSION + harness rc.7 + 当前模型 | notice | ✅ banner-content.ts 常量（spec 守卫 package.json 先例；经新增 `./banner-content` 子路径导出跨包读取）；**版本管控**（2026-08-21 用户裁决）：`packages/transcript/tests/version.spec.ts` 守卫五包 version + BLUE_VERSION + 全部 dsh-* dev 钉版/peer 区间/workspace excludes 同一 lockstep 线 | ✅ S25（2026-08-21） | |
 | `/export [full] [path]` | kimi/pi/CC | 默认路径 | fold.ts 折叠 → Markdown 文件写；`full` 关键字 = 事件流直出完整版（不折叠不过滤，注入带 source 标注） | notice + 路径回显 | ✅ persistence.readRaw（jsonl 后端 supportsRawArtifacts=true 已核实）+ `ctx.sessions.flush` 先冲刷 + fs | S26 | kimi /export-md 同款；debug-zip 不做；上游 Web-only ZIP 版（dsh-session-log-export，§2.10）仅供浏览器面，TUI 独立实现 |
 | `/copy` | kimi/CC/Codex | — | 复制最近一条 assistant 消息文本 | notice（native 计数 / osc52 unverified） | ✅ Blue 侧剪贴板写管线（interaction/src/clipboard-write.ts，注入式探测 wl-copy/xclip/pbcopy/clip.exe，沿 paste-image reader 先例）；OSC 52 ✅ 随批落地（core/terminal-escape.ts 先行发射、工具全败时回退 unverified 报告——原"主屏不可用"经核实系 alt-screen 连坐，纯转义与 scrollback 无关） | S26 | |
-| `/init` | kimi/CC/Codex | — | 罐头提示 followup（分析代码库写 AGENTS.md） | notice | ✅ agent.followup；idle 守卫 | S27 | AGENTS.md 加载面已上游（dsh-agent-instructions，base，§3.2）；/init 仅罐头提示写文件；罐头提示族（/security-review 等）只做这一个，留缝 |
-| `/clear` | kimi(别名)/CC/Codex | — | = /new 语义（kimi 同款；CC"清 transcript 留会话"无原语） | — | ✅ 经 command-meta 别名（§2.12） | S27 | 别名机制已就绪（§2.12），S27 只需 `registerCommandAliases('new', ['clear'])` |
-| `/injections`（2026-08-21 定名——原拟 `/context` 已被 S25 按 CC 语义用于占用面板） | CC | — | 切换注入上下文显隐（D28/S19 默认隐藏的反向开关） | notice + 状态栏 | ✅ fold 注入上下文开关（fold.ts，source.kind!=='user' 分拣）+ settings 持久 | S27' | 开关只影响此后事件，历史不回补 |
+| `/init` | kimi/CC/Codex | — | 罐头提示 followup（分析代码库写 AGENTS.md） | notice | ✅ agent.followup；idle 守卫 | ✅ S27'（2026-08-21） | AGENTS.md 加载面已上游（dsh-agent-instructions，base，§3.2）；/init 仅罐头提示写文件（kimi 文案精神，英文正文，`session-init.ts`）；罐头提示族（/security-review 等）只做这一个，留缝 |
+| `/clear` | kimi(别名)/CC/Codex | — | = /new 语义（kimi 同款；CC"清 transcript 留会话"无原语） | — | ✅ 经 command-meta 别名（§2.12） | ✅ S27'（2026-08-21） | `registerCommandAliases('new', ['clear'])` 一行落地；e2e：下拉别名标注 `/new (clear)` + 执行后 sessionChanges 增长（同 /new） |
+| `/injections`（2026-08-21 定名——原拟 `/context` 已被 S25 按 CC 语义用于占用面板） | CC | — | 切换注入上下文显隐（D28/S19 默认隐藏的反向开关） | — | 🚫 | 🚫 不做 | **2026-08-21 用户裁决**：注入上下文维持 D28 默认隐藏，不开开关（roadmap「预览版后挂起区」有条目）；fold 分拣与 settings 持久能力面保留不动 |
 | `/diff` | CC/Codex | — | git status + git diff（未提交变更）面板 | 全宽面板，复用 DiffCardComponent + line-diff.ts | ✅ spawnSync('git')（status-git 先例，TTL 缓存可复用） | 发版后 | **2026-08-21 用户裁决移出发版范围**（roadmap「预览版后挂起区」有条目）；非 git 仓库报错 |
 | `/hotkeys` | pi | — | 别名 → /help | — | ✅ command-meta（机制已就绪） | 🚫 | **2026-08-21 用户裁决不做**（低价值，/help 已覆盖） |
 | `/settings` | kimi(别名 config)/pi/CC | 列表导航 | 编辑 Blue 自有命名空间（theme custom 路径等）；其他命名空间只读列出 | 列表面板 + 内联编辑（questionnaire 模式） | ⚠️ dsh-settings settingsNamespace + register(schemastery) + patch()；仅 Blue 自有命名空间可写 | S28 | harness 命名空间归其 owner 插件 |
@@ -334,9 +335,9 @@ kimi `KimiSlashCommand`（`apps/kimi-code/src/tui/commands/types.ts`）声明的
 
 见 §6 全表。要点：产品特定（/llama /swarm /web /share /dance /radio /mobile /desktop /powerup /passes /autofix-pr /batch）、无上游能力（/login /logout /goal /cd /vim /memory /trust /scoped-models /tree /branch /clone /session /cost /fast /approve /raw /personality /mute /memories）、既有面覆盖（/plugins /apps /hooks = 组合层；/hotkeys → /help；/changelog → banner；/git → `!` shell；/export-debug-zip → /debug；/keybindings → /help 查看）、评审/诊断族留缝（/security-review /code-review /doctor 仅做 /init 一个罐头提示）。
 
-## 5. 分期实施（S23-S29；S27 于 2026-08-21 砍为 S27'——/hotkeys 🚫、/diff 发版后、注入显隐定名 /injections）
+## 5. 分期实施（S23-S29；S27 于 2026-08-21 两度砍剩——首砍 S27'：/hotkeys 🚫、/diff 发版后、注入显隐定名 /injections；再砍 /injections 🚫（用户裁决维持 D28 默认隐藏），S27' 终版仅 /init /clear，✅ 已落地 2026-08-21）
 
-每步一棵可启动、可验收的插件树（总原则 #1）。依赖链：**S23 的 BlueSessionRef 缝是 S25 /status 读模型的地基，必须第一步开**；S24a 无前置（✅ 已落地 2026-08-21，S24 拆 a/b：用户裁决 /auto 与 /permission 面板顺延）；**S24b（✅ 已落地 2026-08-21，范围收窄——用户裁决 /auto 暂不做，改为 plan-review 专用呈现补入本期）**；S26 依赖 S25 的 fold/累计器；S27 的 command-meta 是 S28 别名/可用性机制的地基（✅ command-meta 已提前落地 2026-08-20，§2.12；S27 只剩消费：`/clear` 别名 + HelpOverlay 分组表头）。S29（`#` 技能管线，D34/D35）无 S 步前置（上游能力全在 base），排在 S28 后收尾命令系列。
+每步一棵可启动、可验收的插件树（总原则 #1）。依赖链：**S23 的 BlueSessionRef 缝是 S25 /status 读模型的地基，必须第一步开**；S24a 无前置（✅ 已落地 2026-08-21，S24 拆 a/b：用户裁决 /auto 与 /permission 面板顺延）；**S24b（✅ 已落地 2026-08-21，范围收窄——用户裁决 /auto 暂不做，改为 plan-review 专用呈现补入本期）**；S26 依赖 S25 的 fold/累计器；S27 的 command-meta 是 S28 别名/可用性机制的地基（✅ command-meta 已提前落地 2026-08-20，§2.12；S27' 消费已落地 2026-08-21：`/clear` 别名——HelpOverlay 分组表头未随期，顺延）。S29（`#` 技能管线，D34/D35）无 S 步前置（上游能力全在 base），排在 S28 后收尾命令系列。
 
 | 步 | 内容 | 能力依赖 | UI 复用 | 验收要点 |
 |---|---|---|---|---|
@@ -345,7 +346,7 @@ kimi `KimiSlashCommand`（`apps/kimi-code/src/tui/commands/types.ts`）声明的
 | **S24b** /permission 面板 + plan-review 呈现 + 通用列表组件（✅ 已落地，范围收窄 2026-08-21） | `/permission` 选择器面板（D33）+ plan-review 专用面板（§7 #5 顺延项提前消费）+ **共享单选列表组件沉淀**（`select-list.ts`：SelectListPanel + cycle/windowedRange/counterRow，回迁 /sessions、/provider、BlueSelect；ModelPanel 保持自有几何）；`/auto` 🚫 暂不做（用户裁决） | `ctx.permissionPresets`（names/current/resolve/optionOf——服务读 ≡ permissions 投影 fold，D33 措辞勘误）；`/permission <name>` 命令写路径（`ctx.commands.execute`，command/run+done 免费入日志）；user-questions `intent {kind:'plan-review'}`（detail=计划 Markdown，答案编码同通用）；type-only 依赖 `@deepseek-ai/dsh-permission-presets`（peer+dev rc.7） | SelectListPanel（D30 挂载）+ FormPanel typed-y danger gate + PlanReviewPanel（kimi approval 形态：plan 边框盒 + 编号列表 Approve/Reject/Revise，Revise 行内联反馈输入） | ✅ 全部达成（2026-08-21）：裸 `/permission` 开面板（e2e：三行 + ← current + knob 派生描述 + Esc 零派发）；danger 必经 typed-y（Esc 回列表、错值留表单）；切换落 `permission/preset`+`sandbox/mode`+`approval/policy` 事件；带参直通命令；plan-review 渲染 Markdown 于 plan 边框盒 + Enter/数字键批准（`plan/mode{active:false}`）/ Reject 本轮拒绝（"chose to keep planning" 入下请求）/ Revise 行内联反馈往返（"their feedback" 入下请求）/ Esc dismissal 走 crafted "speak instead" 消息（ASK_CANCELLED 勘误一并落地） |
 | **S25** 会话信息（✅ 已落地 2026-08-21；`/usage` 落地后经用户裁决更名 `/context`——CC 语义，kimi /usage 同款内容；同批裁决建立全局版本管控 `transcript/tests/version.spec.ts`） | `/status` `/context` `/version` | session.header / requestContext；`sessionProjections.snapshot` 读 tokenUsage/contextPressure/sessionStats 投影（token-meter/session-stats 均在 base）；`usage.ts` 薄读层 + `assistant/*` 纯折回退，不设累计器 | `InfoPanel`（`info-panel.ts`，kimi usage/status 报告形态 × /help 版式：两列 segment 行 + `█░` 严重级占用条 + showing 滚动窗，D30 editor-slot 挂载）+ notice | ✅ 全部达成：数字与投影一致（e2e 断言 64.2k 总数 + 4.1k/60k 分桶）；usage 跨 resume 重放正确（e2e：resume 后同总数）；/version 与 banner 常量一致（同一常量，`./banner-content` 子路径导出）；降级主机回退折 e2e 另证 |
 | **S26** 导出与复制（✅ 已落地 2026-08-21） | `/export` `/copy` | persistence.readRaw（supportsRawArtifacts=true）+ `ctx.sessions.flush` 先冲刷（write-behind coordinator）；fold.ts 折叠→Markdown（`decodeStorageRecord` 展开 chunk 行，新 peer+dev dep dsh-session）；新模块 interaction/src/clipboard-write.ts（注入式探测 wl-copy/xclip/pbcopy/clip.exe） | notice + 路径回显 | ✅ 全部达成：导出文件独立阅读（e2e 断言内容与 turn 结构）；复制文本与最近 assistant 消息一致（e2e 断言 fake writer 收到原文）；无剪贴板工具优雅报错（notice）；readRaw 守卫全分类（无会话/无 persistence/非 raw 后端/无 artifact/空折/坏行/写失败） |
-| **S27'** 轻命令族（2026-08-21 范围修订——用户裁决：`/hotkeys` 🚫 不做、`/diff` 移发版后；注入显隐定名 `/injections`） | `/init` `/clear` `/injections` | command-meta 别名消费；fold 注入上下文开关 + dsh-settings 'blue' 命名空间持久（S28 /settings 首个消费面）；AGENTS.md 加载面已上游（dsh-agent-instructions，§3.2），/init 仅写文件 | notice / HelpOverlay 分组表头（kimi priority 精神） | 别名可补全可执行（/clear = /new）；/init 空仓产出 AGENTS.md 且流式期间守卫拒绝；/injections 开关即时生效、跨会话/跨 resume 持久、历史不回补 |
+| **S27'** 轻命令族（✅ 已落地 2026-08-21；范围两度修订——首砍：用户裁决 `/hotkeys` 🚫 不做、`/diff` 移发版后、注入显隐定名 `/injections`；再砍：用户裁决 `/injections` 🚫 不做（维持 D28 默认隐藏），终版 `/init` `/clear` 两条） | `/init` `/clear` | command-meta 别名消费（`registerCommandAliases('new', ['clear'])`）；AGENTS.md 加载面已上游（dsh-agent-instructions，§3.2），/init 仅罐头提示写文件（`session-init.ts`，kimi 文案精神英文正文） | notice | ✅ 全部达成：/clear 别名可补全（下拉 `/new (clear)` 标注）可执行（e2e 断言 sessionChanges 增长同 /new）；/init 注册可见（/help 列出）+ idle 时罐头提示作为请求发出（e2e 断言 adapter.requests 消息含 exploration brief 与 AGENTS.md）+ 运行中拒绝（notice 断言，followup 不发） |
 | **S28** 配置与生态 | `/settings` `/reload` `/tools` `/tasks` + `/preset`（D33）+ `/mcp`（D36） | dsh-settings 注册 'blue' 命名空间；theme-switch 换装复用；ctx.tools.schemas()（§7 #8 已解决）；todo/write 折叠 + ctx.jobs（pane-todo 同源）；**agent-presets 行（bundle patch 新增 + 包依赖）**；**loader.entries + tools.schemas() mcp__ 分组 + bundle 带 dsh-mcp-client 依赖** | 列表+内联编辑面板（questionnaire 模式）/ notice / pane 面板 | 设置持久生效；/reload 只影响 Blue 自有面；/tools 列表与 schemas() 一致；/tasks = todo 折叠 + jobs 视图一致；/preset 空会话切换成功 + 非空会话守卫报错 + `agent-preset/selected` 事件入日志；/mcp 面板与 loader/tools 实况一致；上游自带命令（/compact /plan /goal /permission /feedback，§2.10）随组合可见且 /help 自动枚举 |
 | **S29** 技能管线 | `#` skills 提示符 + `/skills` 列表命令（D34/D35） | ✅ 上游手势路径（tool-skill pre-step `/name` 注入，base）；ctx.skills.list + isUserInvocable + skills/change；SubmitTransformer `#name`→`/name` 重写（仅命中目录的技能名，保证前置空白） | 补全 UI 复用 `@` 分支形态（S22 file-mention/D31 先例）+ BlueSelect 面板 | `#` 弹补全列 user-invocable 技能、选中插 `#name` 字面文本；提交重写后手势注入生效且 resume 重放正确（注入体按 D28 隐藏）；markdown 标题行（`# ` 空格形态）不误触发；未知 `#tag` 原样保留；/skills 面板与补全目录同源；`skills/change` 后补全刷新 |
 
@@ -484,16 +485,16 @@ kimi `KimiSlashCommand`（`apps/kimi-code/src/tui/commands/types.ts`）声明的
 | `/version` | ✅ | — | — | — | **Adopt**（S25） |
 | `/export` | ✅ | ✅ | ✅ | — | **Adopt**（S26，折叠 Markdown；上游 Web-only ZIP 另注 §2.10） |
 | `/copy` | ✅ | ✅ | ✅ | ✅ | **Adopt**（S26） |
-| `/init` | ✅ | — | ✅ | ✅ | **Adopt**（S27） |
-| `/clear` | 别名 | — | 别名 | ✅ | **Adopt**（S27，= /new 别名） |
-| `/context` | — | — | ✅ | — | **Adopt**（S27，显隐开关） |
-| `/diff` | — | — | ✅ | ✅ | **Adopt**（S27） |
+| `/init` | ✅ | — | ✅ | ✅ | **Adopt**（✅ S27' 2026-08-21） |
+| `/clear` | 别名 | — | 别名 | ✅ | **Adopt**（✅ S27' 2026-08-21，= /new 别名） |
+| `/context` | — | — | ✅ | — | **不做**（2026-08-21 用户裁决：注入显隐维持 D28 默认隐藏，定名 /injections 后再砍——挂起区有条目） |
+| `/diff` | — | — | ✅ | ✅ | **Adopt**（发版后，roadmap 挂起区） |
 | `/settings` | ✅ | ✅ | ✅ | — | **Adapt**（S28，仅 Blue 命名空间可写） |
 | `/reload` | ✅ | ✅ | — | — | **Adapt**（S28，仅 Blue 自有 settings） |
 | `/tools` | ✅ | — | — | — | **Adapt**（S28，消费 ctx.tools.schemas() 真枚举） |
 | `/tasks` | ✅ | — | ✅ | ✅ | **Adapt**（S28，todo 面板 + jobs 视图） |
 | `/import` | — | ✅ | ✅ | ✅ | **Adapt**（顺延，JSONL 校验严格） |
-| `/hotkeys` | — | ✅ | — | — | **Adapt**（S27 可选，→ /help 别名） |
+| `/hotkeys` | — | ✅ | — | — | **不做**（2026-08-21 用户裁决：低价值，/help 已覆盖） |
 | `/compact` | ✅ | ✅ | ✅ | ✅ | **Adopt**（上游自带 /compact，零实现） |
 | `/goal` | ✅ | — | ✅ | — | **Adopt**（上游自带 /goal，零实现） |
 | `/feedback` | ✅ | — | ✅ | ✅ | **Adopt**（上游自带 /feedback，零实现） |
@@ -520,7 +521,7 @@ kimi `KimiSlashCommand`（`apps/kimi-code/src/tui/commands/types.ts`）声明的
 | dsh-commands 无元数据 → 别名靠 Blue 侧解析 | command-meta 层先行（✅ 已落地，§2.12：提交时重写 canonical、显示面零去重），上游缝 #9 落地后退化；不阻塞 |
 | 外部剪贴板工具梯度（wl-copy/xclip/pbcopy/clip.exe 缺失） | clipboard-write 注入式探测 + 优雅 notice（沿 paste-image reader 先例） |
 | /import 的格式严格性（SESSION_FORMAT_VERSION=0、ignorable 标记） | 顺延不阻塞主线（§4.2 表 B 末行） |
-| 命令数增长后 /help 双列拥挤 | S27 顺带 HelpOverlay 分组表头（kimi priority 精神） |
+| 命令数增长后 /help 双列拥挤 | HelpOverlay 分组表头（kimi priority 精神）——原排 S27' 顺带，未随期（拥挤实感出现再做） |
 | /yolo /auto 的"自动放行"语义与 harness policy 'never' 的"不问即拒"冲突 | answerer 侧实现（§4.2.2），不动 harness policy 语义；S24 实施时 🔍 验证 |
 | 模型类命令无 idle 守卫的竞态 | installModelSelection 下一 step 生效语义天然安全（§4.1 第 3 条） |
 | 上游命令面持续扩张（/compact /plan /goal /permission /feedback 随 base 自动注册，rc.8 可能再增） | 命令面核对以 /help 自动枚举为准（§2.10）；本文表 B 仅跟踪 Blue 自注册命令；上游自带命令 Blue 侧只做验收不注册 |

--- a/docs/blue-roadmap.md
+++ b/docs/blue-roadmap.md
@@ -145,7 +145,7 @@ alt-screen、主题切换、自定义键位、steer/cancel 的 UI、diff/termina
 |---|---|---|---|
 | ✅ M0 | S26 合并（/export /copy + OSC 52 + harness 线 0.1.1-rc.1 迁移，e1b507d） | — | — |
 | ✅ R0 | CI 建立（2026-08-21 落地全绿 run 32477151535）：`ci.yml` typecheck→lint→build→test:coverage（push+PR、钉 pnpm、frozen-lockfile；website-only PR 跳过；runner 无 fd 属有意——唯一覆盖 @ 补全 fs fallback 路径的环境。随批三修：interaction tsconfig 补 transcript 项目引用——本地 typecheck 此前靠 lib/ 历史产物假绿；CI 加 pnpm build——spec 经包名入口需 lib/*.js；@ 下钻 e2e 增量帧断言去竞态） | — | — |
-| S27' | 轻命令族：/init（罐头提示写 AGENTS.md + idle 守卫）、/clear（command-meta 一行别名）、**/injections**（注入显隐开关，fold.ts `source.kind` 分拣可开关 + dsh-settings 持久；开关只影响此后事件，历史不回补） | 1d | M0 |
+| S27' | 轻命令族（✅ 已落地 2026-08-21）：/init（罐头提示写 AGENTS.md + idle 守卫，`session-init.ts`）、/clear（command-meta 一行别名 = /new）；**/injections 🚫 用户裁决不做**（2026-08-21：注入上下文维持 D28 默认隐藏，不开开关——挂起区有条目） | 1d | M0 |
 | S28 | 配置与生态：/settings /reload /tools /tasks /preset /mcp（详 commands-plan §5；/preset 需 bundle patch 加 agent-presets 行，/mcp 需 bundle 带 dsh-mcp-client 依赖） | 3d+ | S27' |
 | S29 | 技能管线：**前置修复**（input-plugin 未注册 `/xxx` miss → 回退 `agent.followup`，独立 e2e 钉住）+ `#` 提示符（复用 @ 分支形态 + `#name→/name` 提交重写）+ /skills | 2d | S27'（dev 可‖S28，合并串行） |
 | S30 | 终端小件批：/title + OSC 0/2（core terminal.ts setTitle helper）、模型热键免清空切换（具体键位步内设计，过 keymap 冲突检测）、/sessions type-to-filter（select-list.ts，跨页搜索仍挂起） | 1.5d | S29 |
@@ -173,6 +173,7 @@ alt-screen、主题切换、自定义键位、steer/cancel 的 UI、diff/termina
 | 审批 diff 预览 | 面板内嵌 diff / Ctrl+E 全屏（DiffCardComponent 已备，只差接入审批面板） | 交互形态与参照系对照未调研定稿（⏸️ 维持 2026-08-20 裁定，2026-08-21 复核维持） | 专项调研后立项 |
 | live 工具输出流 | 工具执行中流式呈现（尾行跟随+计时；kimi live 运行卡） | ⛔ 上游无工具输出流事件缝（harness 侧可开） | 上游开出 streaming tool output 事件面 |
 | /hotkeys | = /help 别名 | 低价值（2026-08-21 裁决不做） | 键位数再增一档时随命令系列补录 |
+| /injections | 注入上下文显隐开关（原 S27' 范围项：fold.ts `source.kind` 分拣可开关 + dsh-settings 'blue' 命名空间持久） | 2026-08-21 用户裁决：注入上下文维持 D28/S19 默认隐藏，不开开关 | 真实需求出现再议（届时为 S28 /settings 的首个 'blue' 命名空间消费面） |
 | /diff | 未提交变更面板（DiffCardComponent + line-diff.ts 已备） | 2026-08-21 裁决发版后 | rc.1 dogfood 反馈收集后与审批 diff 预览同评 |
 | alt-screen 及门控项 | TuiAltScreen / OSC 8 可点链接 / 鼠标滚轮与选择 / transcript 全屏搜索 / 主屏滚动冲突 | 维持 2026-08-20 裁定（OSC 52 已解连坐） | 按 p2-visual §7 六轮注记重启立项 |
 | statusline 自定义脚本 | footer 脚本条目（CC statusLine JSON 契约，kimi 已显式镜像） | blueStatus 缝已备，缺脚本宿主与沙箱约定 | 首个真实消费者出现（"首个真实消费者驱动"纪律） |

--- a/packages/bundle/blue/tests/e2e.spec.ts
+++ b/packages/bundle/blue/tests/e2e.spec.ts
@@ -2107,9 +2107,12 @@ describe('blue whole-tree e2e', () => {
     expect(shown).toContain('/btw')
     expect(shown).toContain('Exit Blue')
     expect(shown).toContain('showing 1-16 of')
-    // PageDown twice scrolls to the tail of the Keys section — including
+    // PageDown thrice scrolls to the tail of the Keys section — including
     // the pane-todo global action; the accumulated output carries the rows
-    // once the throttled render settles.
+    // once the throttled render settles. (Three presses since S27' added
+    // /init: 38 content rows need the third 10-row step to clamp at the
+    // scroll floor.)
+    tree.terminal.sendInput('\x1b[6~')
     tree.terminal.sendInput('\x1b[6~')
     tree.terminal.sendInput('\x1b[6~')
     await vi.waitFor(() => { expect(tree.terminal.output).toContain('Toggle todo list expansion') })
@@ -2298,6 +2301,72 @@ describe('blue whole-tree e2e', () => {
     tree.terminal.sendInput('\r')
     await vi.waitFor(() => { expect(tree.terminal.output).toContain('already the current session') })
     expect(tree.sessionChanges).toHaveLength(3)
+  })
+
+  it('/clear completes as an annotated alias of /new and runs its semantics', async () => {
+    const tree = await bootBlue(['first', 'task'], {
+      script: [textResponse('first answer')],
+      persistenceRoot: mkdtempTracked('dsh-blue-e2e-clear-'),
+    })
+    const first = await currentAgent(tree)
+    await vi.waitFor(() => { expect(tree.adapter.requests).toHaveLength(1) })
+    await first.whenIdle()
+
+    // The alias surfaces the canonical command, the label carrying the
+    // alias annotation (`/new (clear)` — the query matched the alias, not
+    // the name). Assert the increment after the keystrokes only: the
+    // accumulated output holds older frames that would false-satisfy.
+    const mark = tree.terminal.written.length
+    tree.terminal.sendInput('/clear')
+    await vi.waitFor(() => {
+      expect(tree.terminal.written.slice(mark).join('')).toContain('/new (clear)')
+    })
+    // Enter runs the alias line's semantics: a fresh session attaches and
+    // the session-changed broadcast fires (the preselected completion and
+    // the raw line both resolve to /new — the value completes to the
+    // canonical name, the input layer rewrites the alias).
+    tree.terminal.sendInput('\r')
+    await vi.waitFor(() => { expect(tree.sessionChanges).toHaveLength(2) })
+    const second = tree.sessionChanges[1]!
+    expect(second.id).not.toBe(first.id)
+  })
+
+  it('/init lists in /help, sends its canned prompt to an idle agent, and refuses while running', async () => {
+    // The listing surface: /help enumerates the command with its summary.
+    const listing = await bootBlue([], { script: [] })
+    const helper = await currentAgent(listing)
+    await expect(executeCommand(listing, helper, '/help')).resolves.toEqual({ kind: 'success' })
+    await vi.waitFor(() => {
+      expect(listing.terminal.output).toContain('Analyze the codebase and write AGENTS.md')
+    })
+
+    // The idle path: the canned prompt rides the next request as a user
+    // message — the exploration brief and the AGENTS.md target are both
+    // model-visible.
+    const tree = await bootBlue([], { script: [textResponse('AGENTS.md written')] })
+    const agent = await currentAgent(tree)
+    await expect(executeCommand(tree, agent, '/init'))
+      .resolves.toEqual({ kind: 'success', text: 'analyzing the codebase to write AGENTS.md' })
+    await vi.waitFor(() => { expect(tree.adapter.requests).toHaveLength(1) })
+    const messages = JSON.stringify(tree.adapter.requests[0]!.messages)
+    expect(messages).toContain('explore the current project directory')
+    expect(messages).toContain('AGENTS.md')
+    await agent.whenIdle()
+
+    // The busy path: a typed /init while the agent runs is refused with a
+    // notice and no second request.
+    const busy = await bootBlue([], { script: ['hang'] })
+    const busyAgent = await currentAgent(busy)
+    typeLine(busy.terminal, 'long work')
+    await vi.waitFor(() => { expect(busy.adapter.requests).toHaveLength(1) })
+    await vi.waitFor(() => { expect(busyAgent.status).toBe('running') })
+    const mark = busy.terminal.written.length
+    typeLine(busy.terminal, '/init')
+    await vi.waitFor(() => {
+      expect(busy.terminal.written.slice(mark).join(''))
+        .toContain('cannot run /init while the agent is running')
+    })
+    expect(busy.adapter.requests).toHaveLength(1)
   })
 
   it('lists the model-family commands in /help', async () => {

--- a/packages/interaction/src/commands-plugin.ts
+++ b/packages/interaction/src/commands-plugin.ts
@@ -5,12 +5,14 @@
  * `blue/request-resume` directly (`/resume` is its alias — the S24a
  * dogfood ruling: one command, both surfaces); `/new` emits
  * `blue/request-new`, and `/fork` emits `blue/request-fork` for the app
- * layer to perform the switch; `/help` lists
+ * layer to perform the switch (`/clear` is `/new`'s alias — the kimi
+ * naming, one command wearing both names); `/help` lists
  * the registered commands and key bindings in an overlay; `/theme` swaps
  * the live theme provider (see `./theme-switch.ts`); `/yolo` and the
  * plan/yolo exclusivity wiring live in `./mode-commands.ts`; the
  * session-info family (`/status` `/usage` `/version`) lives in
- * `./session-commands.ts`.
+ * `./session-commands.ts`; `/init` (the canned AGENTS.md prompt) lives in
+ * `./session-init.ts`.
  * Registrations are
  * effect-bound, so unloading the fiber removes them. Only `commands` is
  * injected: the overlay commands read the Blue display services through
@@ -42,6 +44,7 @@ import { registerModelCommands } from './model-commands.ts'
 import { registerModeCommands, setupModeTracking } from './mode-commands.ts'
 import { registerSessionCommands } from './session-commands.ts'
 import { registerExportCommands } from './session-export.ts'
+import { registerInitCommand } from './session-init.ts'
 import { SelectListPanel } from './select-list.ts'
 import { CURRENT_MARK } from './symbols.ts'
 import { registerThemeCommand } from './theme-switch.ts'
@@ -217,6 +220,11 @@ export function apply(ctx: Context): void {
         return { kind: 'success' as const, text: 'starting a new session' }
       },
     })
+    // `/clear` is the new-session command's alias (the S27 kimi naming:
+    // CC/Codex users reach for /clear to wipe the conversation), not a
+    // registration — the input layer rewrites the line to `/new` before
+    // dispatch, exactly like `/q` → `/quit`.
+    const freshAliases = registerCommandAliases('new', ['clear'])
     const fork = ctx.commands.register({
       name: 'fork',
       description: 'Fork the current session into a new one',
@@ -266,10 +274,13 @@ export function apply(ctx: Context): void {
     const sessionInfo = registerSessionCommands(ctx)
     // The session-export family (`/export` `/copy`).
     const sessionExport = registerExportCommands(ctx)
+    // The canned-prompt command (`/init`).
+    const init = registerInitCommand(ctx)
     return () => {
       quit()
       quitAliases()
       fresh()
+      freshAliases()
       fork()
       sessions()
       sessionsAliases()
@@ -280,6 +291,7 @@ export function apply(ctx: Context): void {
       modeTracking()
       sessionInfo()
       sessionExport()
+      init()
     }
   })
 }

--- a/packages/interaction/src/session-init.ts
+++ b/packages/interaction/src/session-init.ts
@@ -1,0 +1,65 @@
+/**
+ * The `/init` command: one canned prompt, the kimi registry's `init`
+ * spirit — analyze the current codebase and write the findings to
+ * `AGENTS.md` in the project root. The prompt goes to the UI's current
+ * agent as an ordinary user follow-up (`agent.followup`), so the
+ * exploration runs as a normal turn of the live session; the reading side
+ * is already upstream (dsh-agent-instructions feeds `AGENTS.md` into later
+ * sessions), the command only seeds the writing side. A non-idle agent
+ * refuses the invocation — a second canned prompt would interleave with
+ * the running turn (the /fork guard's rule; the kimi registry marks `init`
+ * idle-only the same way).
+ *
+ * @module @dsh-blue/blue-interaction/session-init
+ */
+
+import type { Context } from '@deepseek-ai/cordis'
+import type { CommandResult } from '@deepseek-ai/dsh-commands'
+import { createUserMessage } from '@deepseek-ai/dsh-llm'
+import { currentBlueAgent } from './session.ts'
+
+/**
+ * The canned exploration prompt `/init` submits as a follow-up turn: the
+ * kimi text's spirit (structure, stack, conventions, then one coherent
+ * `AGENTS.md` for a reader who knows nothing about the project) in Blue's
+ * English UI voice.
+ */
+const INIT_PROMPT = [
+  'Please explore the current project directory and analyze the codebase.',
+  '',
+  'Specifically:',
+  '1. Identify the key configuration files and the technology stack (languages, frameworks, package manager).',
+  '2. Understand the build process, the test setup, and how to run them.',
+  '3. Map how the code is organized: the main modules and what each owns.',
+  '4. Note project-specific development conventions: code style, testing strategy, anything unusual.',
+  '',
+  'Then write your findings to the AGENTS.md file in the project root, aimed at AI coding agents who know nothing about the project. If AGENTS.md already exists, read it first and carry forward whatever is still accurate — rewrite it into one coherent, up-to-date file rather than appending. Compose it from what you can verify in the repository, without assumptions or generalizations, and write it in the natural language the project\'s own comments and documentation mainly use.',
+].join('\n')
+
+/**
+ * Register the `/init` command on `ctx.commands`. The handler targets the
+ * UI's current agent (not necessarily the dispatching one — the /fork
+ * rule) and refuses while it is running.
+ * @param ctx - plugin context carrying the command registry.
+ * @returns the registration disposer.
+ */
+export function registerInitCommand(ctx: Context): () => void {
+  return ctx.commands.register({
+    name: 'init',
+    description: 'Analyze the codebase and write AGENTS.md',
+    handler: (): CommandResult => {
+      const agent = currentBlueAgent(ctx)
+      if (agent === undefined) {
+        return { kind: 'error', text: 'no active session' }
+      }
+      if (agent.status !== 'idle') {
+        return { kind: 'error', text: 'cannot run /init while the agent is running' }
+      }
+      agent.followup(createUserMessage({
+        content: [{ type: 'text', text: INIT_PROMPT }],
+        source: { kind: 'user' },
+      }))
+      return { kind: 'success', text: 'analyzing the codebase to write AGENTS.md' }
+    },
+  })
+}

--- a/packages/interaction/tests/commands-plugin.spec.ts
+++ b/packages/interaction/tests/commands-plugin.spec.ts
@@ -120,6 +120,21 @@ describe('blue-commands plugin', () => {
     expect(execution?.result).toEqual({ kind: 'success', text: 'starting a new session' })
   })
 
+  it('/clear is the /new alias, not a registration', async () => {
+    const { ctx, agent } = await mount()
+    // The S27 alias relation: the input layer rewrites `/clear` to `/new`
+    // before dispatch (kimi's one-command-two-names rule), so the harness
+    // registry stays canonical-only and the session log records /new.
+    expect(canonicalOf('clear')).toBe('new')
+    expect(ctx.commands.find(agent, 'clear')).toBeUndefined()
+    expect(await ctx.commands.execute(agent, '/clear', [], signal())).toBeUndefined()
+    const onNew = vi.fn()
+    ctx.on('blue/request-new', onNew)
+    const rewritten = await ctx.commands.execute(agent, '/new', [], signal())
+    expect(onNew).toHaveBeenCalledOnce()
+    expect(rewritten?.result).toEqual({ kind: 'success', text: 'starting a new session' })
+  })
+
   it('/fork emits blue/request-fork while the current session is idle', async () => {
     const { ctx, agent } = await mount()
     const onFork = vi.fn()
@@ -290,15 +305,15 @@ describe('blue-commands plugin', () => {
     expect(rows[4]).toBe('    ^/context           ^  ~Show token usage and the context window~')
     expect(rows.some(row => row.includes('^/effort (/thinking)^  ~Switch the thinking effort of the current model~'))).toBe(true)
     expect(rows.some(row => row.includes('^/quit (/q, /exit)  ^  ~Exit Blue~'))).toBe(true)
-    // 31 rows since the S26 export family joined the command list.
-    expect(rows.some(row => row.includes('_ showing 1-16 of 31_'))).toBe(true)
+    // 32 rows since S27' added /init to the command list (31 at S26).
+    expect(rows.some(row => row.includes('_ showing 1-16 of 32_'))).toBe(true)
     // Scrolling down reaches the Keys section with the two-column layout.
     for (let i = 0; i < 10; i += 1) overlay(screen).handleInput(KEY.down)
     const scrolled = screen.overlays[0]?.component.render(80) ?? []
     expect(scrolled.some(row => row.includes('  #Keys#'))).toBe(true)
     // Key labels padEnd to the longest label — `backspace` (9) since S13.
     expect(scrolled.some(row => row.includes('?enter    ?  ~Submit input / confirm selection~'))).toBe(true)
-    expect(scrolled.some(row => row.includes('_ showing 11-26 of 31_'))).toBe(true)
+    expect(scrolled.some(row => row.includes('_ showing 11-26 of 32_'))).toBe(true)
     screen.overlays[0]?.component.invalidate()
     overlay(screen).handleInput(KEY.escape)
     expect(screen.overlays[0]?.hidden).toBe(true)

--- a/packages/interaction/tests/session-init.spec.ts
+++ b/packages/interaction/tests/session-init.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the `/init` command: the canned prompt rides a user follow-up
+ * on the UI's current agent, a running agent refuses the invocation, and
+ * no attached session reports its error. The command registers through
+ * `registerInitCommand` on the real command runtime; the agent is the
+ * spec's fake with a recording `followup`.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import type { Agent } from '@deepseek-ai/dsh-agent'
+import type { UserMessage } from '@deepseek-ai/dsh-llm'
+import SessionStore, { SessionId } from '@deepseek-ai/dsh-session'
+import CommandRuntime from '@deepseek-ai/dsh-commands'
+import { registerInitCommand } from '../src/session-init.ts'
+import type {} from '@dsh-blue/blue-app'
+
+async function mount(options: {
+  status?: 'idle' | 'running'
+  attach?: boolean
+} = {}): Promise<{
+  ctx: Context
+  agent: Agent
+  followup: ReturnType<typeof vi.fn>
+  dispose: () => void
+}> {
+  const ctx = new Context()
+  await ctx.plugin(SessionStore)
+  await ctx.plugin(CommandRuntime)
+  const session = ctx.sessions.create(SessionId('init-spec'))
+  const followup = vi.fn()
+  const agent = {
+    id: session.id,
+    session,
+    status: options.status ?? 'idle',
+    followup,
+  } as unknown as Agent
+  if (options.attach !== false) ctx.provide('blueSession', { current: agent, modelRef: undefined })
+  const dispose = registerInitCommand(ctx)
+  return { ctx, agent, followup, dispose }
+}
+
+describe('/init command', () => {
+  it('sends the canned AGENTS.md prompt as a user follow-up when idle', async () => {
+    const { ctx, agent, followup } = await mount()
+    const execution = await ctx.commands.execute(agent, '/init', [], new AbortController().signal)
+    expect(execution?.result).toEqual({
+      kind: 'success',
+      text: 'analyzing the codebase to write AGENTS.md',
+    })
+    expect(followup).toHaveBeenCalledTimes(1)
+    const message = followup.mock.calls[0]![0] as UserMessage
+    expect(message.role).toBe('user')
+    expect(message.source).toEqual({ kind: 'user' })
+    const text = JSON.stringify(message.content)
+    // The kimi prompt's load-bearing lines: the exploration brief, the
+    // target file, and the replace-not-append rule.
+    expect(text).toContain('explore the current project directory')
+    expect(text).toContain('AGENTS.md')
+    expect(text).toContain('one coherent, up-to-date file')
+  })
+
+  it('refuses the invocation while the agent is running', async () => {
+    const { ctx, agent, followup } = await mount({ status: 'running' })
+    const execution = await ctx.commands.execute(agent, '/init', [], new AbortController().signal)
+    expect(execution?.result).toEqual({
+      kind: 'error',
+      text: 'cannot run /init while the agent is running',
+    })
+    expect(followup).not.toHaveBeenCalled()
+  })
+
+  it('reports an error when no session is attached', async () => {
+    const { ctx, agent, followup } = await mount({ attach: false })
+    const execution = await ctx.commands.execute(agent, '/init', [], new AbortController().signal)
+    expect(execution?.result).toEqual({ kind: 'error', text: 'no active session' })
+    expect(followup).not.toHaveBeenCalled()
+  })
+
+  it('unregisters with its disposer', async () => {
+    const { ctx, agent, dispose } = await mount()
+    dispose()
+    const execution = await ctx.commands.execute(agent, '/init', [], new AbortController().signal)
+    expect(execution).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What

S27' light-commands family, final scope after the two 2026-08-21 cuts (/injections dropped, /hotkeys and /diff already out):

- **`/init`** (`packages/interaction/src/session-init.ts`) — canned-prompt command: the idle current agent receives the AGENTS.md exploration brief (kimi's `init` prompt spirit, English body) as an ordinary user followup via `agent.followup`; a running agent is refused with an error notice (the `/fork` guard rule; kimi marks `init` idle-only the same way).
- **`/clear`** — `/new`'s alias, one line: `registerCommandAliases('new', ['clear'])`. Not a registration: the input layer rewrites the line to `/new` before dispatch (§2.12 mechanism), the slash dropdown annotates the match as `/new (clear)`.

## Tests

- New unit spec `session-init.spec.ts` (idle followup content + source, running refusal, no-session error, disposer) and a `/clear`-alias case in `commands-plugin.spec.ts`; the `/help` window-count assertions move 31 → 32 rows.
- New e2e cases: `/clear` dropdown alias annotation + `sessionChanges` growth after Enter (same as `/new`); `/init` listed in `/help`, canned prompt asserted in `adapter.requests` messages, busy-path notice asserted on the incremental frame.
- Gates: typecheck / lint / build / `test:coverage` all green — **1364 tests, 85 files**, per-file coverage 100%.

## Docs (same PR)

- `blue-commands-plan.md`: §2.6/§4.2 `/injections` → 🚫 dropped (2026-08-21 user ruling: injected context stays D28-hidden, no toggle); §5 S27' row rewritten to the shipped scope and acceptance points; shipped-commands table grows to 15.
- `blue-roadmap.md`: sprint S27' row synced; `/injections` added to the parked table (reason = user ruling, unlock = real demand).
- `README.md` / `README.zh.md`: command list gains `/init` and the `/clear` alias annotation. website/ untouched (D32: R6 settles it in one pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)