### PR TITLE
docs(website): configuration guide — models, providers, and the one-key quickstart

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -97,6 +97,7 @@ const sidebarZh = {
       text: '指南',
       items: [
         { text: '快速上手', link: '/guide/' },
+        { text: '配置', link: '/guide/config' },
         { text: '主题', link: '/guide/theme' },
         { text: '常见问题', link: '/guide/faq' },
       ],
@@ -154,6 +155,7 @@ const sidebarEn = {
       text: 'Guide',
       items: [
         { text: 'Quickstart', link: '/en/guide/' },
+        { text: 'Configuration', link: '/en/guide/config' },
         { text: 'Theming', link: '/en/guide/theme' },
         { text: 'FAQ', link: '/en/guide/faq' },
       ],

--- a/website/en/guide/config.md
+++ b/website/en/guide/config.md
@@ -1,0 +1,170 @@
+# Configuration: models, providers, and themes
+
+Blue's configuration lives on two layers: **in-app slash commands** (the everyday surface) and **dsh's file system** (`settings.yaml`, `.credentials.yaml`, profile patches — the persistent source of truth). The in-app commands write to those same files; the two layers never fight. This page walks both.
+
+| What you want | In-app | Where it lands |
+| --- | --- | --- |
+| API key | `/provider add`, the Providers panel's edit form | `~/.dsh/.credentials.yaml` |
+| Default model / thinking effort | `/model`, `/effort`, `Alt+M` | the `agent-default-model:` section of `settings.yaml` |
+| New provider / custom gateway | `/provider add` | the `llm-pi-ai:` section of `settings.yaml` + the credentials file |
+| DeepSeek official endpoint tuning | — (files only) | the `llm-deepseek:` section of `settings.yaml` |
+| Theme | `/theme` | session-only, no file ([Theming](/en/guide/theme)) |
+| Plugin rows / composition | — | the profile's `cordis.patch.yml` ([Profiles & directories](/en/dsh/profiles)) |
+
+## Minimal setup: one DEEPSEEK_API_KEY
+
+The out-of-the-box assembly talks to the **DeepSeek official API** (provider route `deepseek-official`, endpoint `https://api.deepseek.com`, default model `deepseek-v4-flash`, thinking on at effort `high`). So getting from zero to your first reply takes exactly one key:
+
+```sh
+export DEEPSEEK_API_KEY=sk-...
+dsh --profile blue
+```
+
+To skip the export every time, write the key into `~/.dsh/.credentials.yaml` — the whole document is a plain reference → value mapping and nothing else:
+
+```yaml
+DEEPSEEK_API_KEY: sk-...
+```
+
+One key can sit in four places, in **priority order**:
+
+| Priority | Source | Use it for |
+| --- | --- | --- |
+| 1 | Process environment (`DEEPSEEK_API_KEY=… dsh …`) | Per-run override: CI secrets, a temporary key |
+| 2 | `~/.dsh/.credentials.yaml` | The normal home; keys stored by `/provider add` land here |
+| 3 | `./.env` in the launch directory | Project-level |
+| 4 | `~/.dsh/.env` | User-level fallback |
+
+::: tip It starts fine without a key
+The key resolves **per request** — booting, browsing models, and the `/model` panel never need it. The first real message with no key anywhere fails with `MISSING_CREDENTIAL` naming every configuration entry point; store the key and ask again — **no restart needed**.
+:::
+
+`~/.dsh` is the Harness home; `DSH_HOME` relocates it (full directory table in [Profiles & directories](/en/dsh/profiles)).
+
+## In-app configuration (the everyday surface)
+
+### Model and thinking effort
+
+- **`/model`** — no argument opens the model picker (`←` `→` step the thinking-effort segment); with an id it switches directly. A switch persists as the new default.
+- **`Alt+M`** — cycles models without opening the panel.
+- **`Alt+S`** (inside the panel) — confirm **for this session only**: the next step switches immediately without persisting a new default.
+- **`/effort`** (alias `/thinking`) — switch the current model's thinking effort; `default` restores the provider default.
+
+`/model` persistence lands in the `agent-default-model:` section of settings.yaml (shape [below](#the-three-core-settings-yaml-sections)).
+
+### Providers: list, switch, add
+
+```
+/provider                  # open the Providers panel (configured routes + Add)
+/provider list             # list providers and the current route
+/provider switch <name>    # switch routes
+/provider add              # the add-provider wizard
+```
+
+Selecting a configured route in the Providers panel opens its **edit form**: display name, baseURL, and key (empty keeps the stored value); `Ctrl+D` deletes the route after a typed confirmation. The built-in `deepseek-official` route has no stored profile to edit (the panel says "nothing to edit") — tune it through the `llm-deepseek:` section of `settings.yaml`.
+
+`/provider add` branches two ways:
+
+- **Known provider** (anthropic, openai, …) — pick a vendor from the host's configurable directory and enter the key (leave baseURL empty for the vendor default).
+- **Custom endpoint** (self-hosted gateways, any OpenAI-compatible surface) — declare protocol and address:
+  - one of three protocols: `anthropic-messages` / `openai-completions` / `openai-responses`;
+  - baseURL conventions: the anthropic protocol takes **no trailing** `/v1` (the client appends `/v1/messages` itself); the openai protocols **need** the `/v1`;
+  - the wizard interrogates the endpoint live for its model list (`GET /models`) for you to pick from, then enriches context windows and efforts from the [models.dev](https://models.dev) catalog — whatever it cannot describe, it asks you once (both fields skippable with Enter);
+  - the key goes into the credentials file under a ref derived from the route id: `my-gateway` → `MY_GATEWAY_API_KEY`.
+
+After the add completes, the new route's model picker opens; cancelling it keeps the provider (visible via `/provider list`).
+
+## The file system: settings.yaml and credentials
+
+Beyond the in-app commands, all of dsh's configuration sits in a handful of files under the Harness home, and **external edits hot-apply** (the watcher is on by default):
+
+| File | Contents |
+| --- | --- |
+| `~/.dsh/settings.yaml` | Every plugin's settings section (one document, all namespaces) |
+| `~/.dsh/.credentials.yaml` | Credentials (enforced mode `0600` under a `0700` directory) |
+| `~/.dsh/.env` | User-level environment layer |
+| `~/.dsh/profiles/<name>/cordis.patch.yml` | The profile's composition overlay (see [Profiles & directories](/en/dsh/profiles)) |
+
+A document that exists but fails to parse fails boot (loud); an invalid edit while running keeps the last good snapshot and warns. Hand edits to settings.yaml keep their comments (writes diff at the leaf level).
+
+### The three core settings.yaml sections
+
+```yaml
+# Default model — /model and /effort write here
+agent-default-model:
+  provider: deepseek-official
+  model: deepseek-v4-flash
+  reasoningEffort: high      # optional
+
+# DeepSeek official endpoint (the llm-deepseek adapter) — every field optional
+llm-deepseek:
+  apiKeyEnv: DEEPSEEK_API_KEY    # credential ref (this is the default)
+  baseURL: https://api.deepseek.com
+  thinking: enabled              # enabled | disabled (disabled locks effort to off)
+  reasoningEffort: high          # off | high | max
+  maxTokens: 256000              # per-request output cap
+  defaultContextWindow: 1000000  # fallback when a model declares no capacity
+  models:                        # omit for the built-in V4 Flash / V4 Pro pair
+    - id: deepseek-v4-flash
+      name: DeepSeek-V4-Flash
+      contextWindow: 1000000
+
+# Custom provider routes (the pi-ai adapter) — /provider add writes here
+llm-pi-ai:
+  providers:
+    my-gateway:
+      displayName: Company gateway
+      api: openai-completions          # anthropic-messages | openai-completions | openai-responses
+      baseURL: https://gw.example.com/v1
+      apiKeyEnv: MY_GATEWAY_API_KEY    # credential ref — the key in .credentials.yaml
+      models:
+        - id: glm-5.3
+          contextWindow: 1000000       # capacity the catalog/endpoint did not declare
+          maxTokens: 131072
+          reasoningEfforts:            # offered efforts → their wire spellings
+            low: low
+            high: high
+            max: max
+```
+
+Notes:
+
+- **`llm-deepseek:` and `llm-pi-ai:` are two independent adapters**: the former owns the `deepseek-official` route to the official API; the latter registers arbitrary routes from its `providers:` dict (the route name is the dict key, lowercase kebab-case). They coexist fine.
+- A user settings section overrides the composition baseline (the bundle's defaults) **field by field**; omitted fields keep the baseline value.
+- pi-ai routes take further fields: `modelOverrides:` (reshape one catalog model without replacing the list), `compat:` (reasoning-parameter format switches), `defaultContextWindow:` / `defaultMaxTokens:` (route-wide fallbacks), and more — the complete list lives in the [upstream config catalog](https://deepseek-harness.github.io/deepseek-harness/reference/).
+- List fields (like `models:`) **replace wholesale**, they never merge entry by entry.
+
+### Verifying your edits
+
+```sh
+dsh --profile blue --dump-config        # print the fully assembled plugin tree
+```
+
+settings.yaml effects show up right in the UI: the `/model` panel lists each route's models, `/status` shows the current route and model.
+
+## Themes
+
+`/theme dark|light|auto` switches instantly; `/theme custom <path>` mounts a custom JSON palette — hot switches never lose your draft. The full semantic token table and the custom file format are in [Theming](/en/guide/theme).
+
+## Other configuration surfaces
+
+- **Permissions & sandbox** — permission presets (workspace-write / danger-full-access), approval policies, see [Modes & permissions](/en/dsh/modes); in-session `Shift+Tab` cycles normal → plan → yolo, `/yolo` toggles.
+- **Agent presets** — `/preset` switches tool surface and persona across `standard` / `code` / `minimal` / `cordis` (blank sessions only).
+- **Skills** — user-level skills live under `~/.dsh/skills/`, see [Skills](/en/dsh/skills).
+- **MCP** — wiring MCP servers is covered in [MCP setup](/en/dsh/mcp).
+
+## Environment variable quick reference
+
+| Variable | Purpose | Default behavior |
+| --- | --- | --- |
+| `DEEPSEEK_API_KEY` | DeepSeek official API key (the default `apiKeyEnv` ref of `llm-deepseek`) | Missing → first request fails with `MISSING_CREDENTIAL` |
+| `DEEPSEEK_BASE_URL` | DeepSeek official endpoint fallback | `https://api.deepseek.com` |
+| `DSH_HOME` | Harness home directory | `~/.dsh` |
+| `DSH_PERMISSION_MODE` | Process-level permission fallback: `read-only` / `workspace-write` / `danger-full-access` (the last also skips approvals) | `workspace-write` |
+| `DSH_TELEMETRY_DISABLED` | Any non-empty value (including `'0'` / `'false'`) hard-disables session telemetry | Telemetry is off by default (`DISABLED`) |
+| `DSH_BLUE_ATTACHMENT_DIR` | Blue attachment storage | `$DSH_HOME/attachments/` |
+| `DSH_AGENTS_HOME` | Shared agent config root (the `~/.agents` layer of skill discovery) | `~/.agents` |
+
+::: warning What cannot live in .env
+`DEEPSEEK_API_KEY` resolves from all four layers (`.env` included), but `DEEPSEEK_BASE_URL` and **every `DSH_*`-prefixed variable** are bootstrap variables — a `.env` file entry is rejected outright (with an "export it instead" notice); set them in the launching environment. Credential environment variables always beat the file layers — to swap a key for one run: `DEEPSEEK_API_KEY=sk-… dsh --profile blue`.
+:::

--- a/website/en/guide/index.md
+++ b/website/en/guide/index.md
@@ -44,6 +44,16 @@ dsh --profile blue --resume <id>    # resume a persisted session
 If your profile was linked before the package rename (when the packages were named `@dsh-blue/blue*`), those links are stale — delete the profile directory (`~/.dsh/profiles/<name>`) or `dsh plugin --profile <name> remove` the old entries, then re-run the script.
 :::
 
+## One key before you ride
+
+**A single `DEEPSEEK_API_KEY` is all it takes to start using Blue** — the out-of-the-box default talks to the DeepSeek official API (route `deepseek-official`, default model `deepseek-v4-flash`); nothing else to configure:
+
+```sh
+export DEEPSEEK_API_KEY=sk-...        # or store it in ~/.dsh/.credentials.yaml, once and for all
+```
+
+Switching models, wiring custom gateways, theming, and more: [Configuration](/en/guide/config).
+
 ## First run
 
 ```sh

--- a/website/guide/config.md
+++ b/website/guide/config.md
@@ -1,0 +1,170 @@
+# 配置：模型、Provider 与主题
+
+Blue 的配置分两层：**界面内的斜杠命令**（日常切换，推荐）与 **dsh 的文件体系**（`settings.yaml`、`.credentials.yaml`、profile patch——持久化真相就在这些文件里）。界面命令写下去的也是文件；两层从不打架。本页把两层串成一条路。
+
+| 想配什么 | 界面内 | 落盘位置 |
+| --- | --- | --- |
+| API key | `/provider add`、Providers 面板编辑 | `~/.dsh/.credentials.yaml` |
+| 默认模型 / 思考力度 | `/model`、`/effort`、`Alt+M` | `settings.yaml` 的 `agent-default-model:` 段 |
+| 新增 provider / 自定义网关 | `/provider add` | `settings.yaml` 的 `llm-pi-ai:` 段 + 凭据文件 |
+| DeepSeek 官方端点微调 | —（文件专属） | `settings.yaml` 的 `llm-deepseek:` 段 |
+| 主题 | `/theme` | 会话级，不落盘（[主题](/guide/theme)） |
+| 插件行 / 装配 | — | profile 的 `cordis.patch.yml`（[Profile 与目录](/dsh/profiles)） |
+
+## 最小可用：一个 DEEPSEEK_API_KEY
+
+开箱即用的默认装配是 **DeepSeek 官方 API**（provider 路由 `deepseek-official`，端点 `https://api.deepseek.com`，默认模型 `deepseek-v4-flash`，思考默认开启、力度 `high`）。所以从零到第一句对话，只需要一个 key：
+
+```sh
+export DEEPSEEK_API_KEY=sk-...
+dsh --profile blue
+```
+
+不想每次 export，就把 key 写进凭据文件 `~/.dsh/.credentials.yaml`（整份文件就是一个「引用名 → 值」的映射，没有别的结构）：
+
+```yaml
+DEEPSEEK_API_KEY: sk-...
+```
+
+同一个 key 有四种放置方式，按**优先级从高到低**：
+
+| 优先级 | 来源 | 说明 |
+| --- | --- | --- |
+| 1 | 进程环境变量（`export DEEPSEEK_API_KEY=… dsh …`） | 单次覆盖：CI secret、临时换 key |
+| 2 | `~/.dsh/.credentials.yaml` | 常规存放处；`/provider add` 存的 key 也在这里 |
+| 3 | 当前目录 `./.env` | 项目级 |
+| 4 | `~/.dsh/.env` | 用户级兜底 |
+
+::: tip 没有 key 也能启动
+key 在**每次请求时**才解析——启动、浏览模型列表、`/model` 面板都不需要它。第一次真正发消息时若无处可取，会报 `MISSING_CREDENTIAL` 并列出所有可配置入口；补好 key 再问一次即可，**无需重启**。
+:::
+
+`~/.dsh` 称为 Harness home，可用 `DSH_HOME` 改址（目录全表见 [Profile 与目录](/dsh/profiles)）。
+
+## 界面内配置（日常推荐）
+
+### 模型与思考力度
+
+- **`/model`** —— 无参数打开模型选择面板（`←` `→` 步进思考力度 segment）；带 id 直接切换。切换会持久化为新默认。
+- **`Alt+M`** —— 不开面板直接循环切换模型。
+- **`Alt+S`**（面板内）—— **仅本会话**确认：下一步路由立即切换，但不写回持久默认。
+- **`/effort`**（别名 `/thinking`）—— 切换当前模型的思考力度；`default` 恢复 provider 默认。
+
+`/model` 的持久化写入 settings.yaml 的 `agent-default-model:` 段（形状见[下文](#settings-yaml-三个核心段)）。
+
+### Provider：列出、切换、新增
+
+```
+/provider                  # 打开 Providers 面板（列出已配置路由 + Add 入口）
+/provider list             # 命令行列出可用 provider 与当前路由
+/provider switch <name>    # 切换路由
+/provider add              # 新增 provider 向导
+```
+
+Providers 面板里**选中一个已配置的路由即进入编辑**：可改显示名、baseURL、key（留空保留原值），`Ctrl+D` 删除整个路由（需键入 `y` 二次确认）。内置的 `deepseek-official` 路由没有可编辑的存储档案（面板会提示 nothing to edit）——调整它走 `settings.yaml` 的 `llm-deepseek:` 段。
+
+`/provider add` 有两条分支：
+
+- **Known provider**（anthropic、openai 等）—— 从宿主的可配置目录里挑一家，填 key（baseURL 留空用厂商默认端点）。
+- **Custom endpoint**（自建网关、任意 OpenAI 兼容端点）—— 声明协议与地址：
+  - 协议三选一：`anthropic-messages` / `openai-completions` / `openai-responses`；
+  - baseURL 约定：anthropic 协议**不带**尾缀 `/v1`（客户端自己拼 `/v1/messages`）；openai 系协议**要带** `/v1`；
+  - 向导会现场向端点拉取模型列表（`GET /models`）让你勾选，并用 [models.dev](https://models.dev) 目录自动补全上下文窗口与思考力度，补不全的再问你一次（两项都可回车跳过）；
+  - key 存进凭据文件，引用名按路由 id 大写折叠推导：`my-gateway` → `MY_GATEWAY_API_KEY`。
+
+新增完成后弹出新路由的模型选择器；取消选择不会撤销新增（provider 留在原处，`/provider list` 可见）。
+
+## 文件体系：settings.yaml 与凭据
+
+界面命令之外，dsh 的全部配置落在 Harness home 的几个文件里，**外部编辑实时热生效**（watcher 默认开启）：
+
+| 文件 | 内容 |
+| --- | --- |
+| `~/.dsh/settings.yaml` | 所有插件的设置段（一个文档承载全部命名空间） |
+| `~/.dsh/.credentials.yaml` | 凭据（权限强制 `0600`，目录 `0700`） |
+| `~/.dsh/.env` | 用户级环境变量层 |
+| `~/.dsh/profiles/<name>/cordis.patch.yml` | profile 的装配覆盖层（见 [Profile 与目录](/dsh/profiles)） |
+
+启动时文档已存在但格式非法 → 启动失败（fail loud）；运行中的非法编辑 → 保留上一份好快照并告警。手工编辑 settings.yaml 的注释会尽量保留（写入按叶子级 diff 落笔）。
+
+### settings.yaml 三个核心段
+
+```yaml
+# 默认模型——/model、/effort 写到这里
+agent-default-model:
+  provider: deepseek-official
+  model: deepseek-v4-flash
+  reasoningEffort: high      # 可省略
+
+# DeepSeek 官方端点（llm-deepseek 适配器）——全部字段可省略
+llm-deepseek:
+  apiKeyEnv: DEEPSEEK_API_KEY    # 凭据引用名（默认值就是它）
+  baseURL: https://api.deepseek.com
+  thinking: enabled              # enabled | disabled（disabled 锁死 off）
+  reasoningEffort: high          # off | high | max
+  maxTokens: 256000              # 每请求输出上限
+  defaultContextWindow: 1000000  # 模型未声明容量时的兜底
+  models:                        # 省略则内置 V4 Flash / V4 Pro 两条
+    - id: deepseek-v4-flash
+      name: DeepSeek-V4-Flash
+      contextWindow: 1000000
+
+# 自定义 provider 路由（pi-ai 适配器）——/provider add 写到这里
+llm-pi-ai:
+  providers:
+    my-gateway:
+      displayName: 公司网关
+      api: openai-completions          # anthropic-messages | openai-completions | openai-responses
+      baseURL: https://gw.example.com/v1
+      apiKeyEnv: MY_GATEWAY_API_KEY    # 凭据引用名，对应 .credentials.yaml 里的键
+      models:
+        - id: glm-5.3
+          contextWindow: 1000000       # 目录/端点都没声明时的容量声明
+          maxTokens: 131072
+          reasoningEfforts:            # 模型支持的思考力度 → 线上拼写
+            low: low
+            high: high
+            max: max
+```
+
+要点：
+
+- **`llm-deepseek:` 与 `llm-pi-ai:` 是两个独立适配器**：前者独占 `deepseek-official` 路由直连官方 API；后者按 `providers:` 字典注册任意路由（路由名就是字典键，小写 kebab-case）。两者可并存。
+- 用户 settings 段**逐字段覆盖**装配基线（bundle 带来的默认），没有的字段继续用基线值。
+- pi-ai 路由还有进阶字段：`modelOverrides:`（按模型 id 微调目录模型而不替换整个列表）、`compat:`（推理参数格式开关）、`defaultContextWindow:` / `defaultMaxTokens:`（整路由兜底）等，完整清单见[上游配置目录](https://deepseek-harness.github.io/deepseek-harness/reference/)。
+- 列表类字段（如 `models:`）是**整体替换**而非逐条合并。
+
+### 改完怎么验证
+
+```sh
+dsh --profile blue --dump-config        # 打印实际组装的完整插件树
+```
+
+settings.yaml 的效果则直接在界面里看：`/model` 面板列出各路由的模型、`/status` 显示当前路由与模型。
+
+## 主题
+
+`/theme dark|light|auto` 一键切换，`/theme custom <path>` 挂载自定义 JSON 调色板——热切换不丢输入草稿。完整语义 token 表与 custom 文件格式见[主题](/guide/theme)。
+
+## 更多配置面
+
+- **权限与沙箱** —— 权限预设（workspace-write / danger-full-access）、审批策略，见[权限与模式](/dsh/modes)；会话内 `Shift+Tab` 循环 normal → plan → yolo，`/yolo` 开关。
+- **Agent 预设** —— `/preset` 在 `standard` / `code` / `minimal` / `cordis` 间切换工具面与人格（仅空会话）。
+- **Skills** —— 用户级技能放 `~/.dsh/skills/`，见 [Skills](/dsh/skills)。
+- **MCP** —— MCP server 的接入配置见 [MCP 配置](/dsh/mcp)。
+
+## 环境变量速查
+
+| 变量 | 作用 | 默认行为 |
+| --- | --- | --- |
+| `DEEPSEEK_API_KEY` | DeepSeek 官方 API key（`llm-deepseek` 的 `apiKeyEnv` 默认引用名） | 未设置时首次请求报 `MISSING_CREDENTIAL` |
+| `DEEPSEEK_BASE_URL` | DeepSeek 官方端点地址兜底 | `https://api.deepseek.com` |
+| `DSH_HOME` | Harness home 目录 | `~/.dsh` |
+| `DSH_PERMISSION_MODE` | 进程级权限回退：`read-only` / `workspace-write` / `danger-full-access`（后者连审批都跳过） | `workspace-write` |
+| `DSH_TELEMETRY_DISABLED` | 任意非空值（含 `'0'`、`'false'`）即硬禁用会话遥测 | 遥测默认已关闭（`DISABLED`） |
+| `DSH_BLUE_ATTACHMENT_DIR` | Blue 附件存储位置 | `$DSH_HOME/attachments/` |
+| `DSH_AGENTS_HOME` | 共享 agent 配置根（技能发现的 `~/.agents` 层） | `~/.agents` |
+
+::: warning 哪些变量不能写进 .env
+`DEEPSEEK_API_KEY` 四层都认（含 `.env`），但 `DEEPSEEK_BASE_URL` 与**一切 `DSH_*` 前缀变量**属于 bootstrap 变量——`.env` 文件里出现会被直接拒绝（提示 export 它），只能在启动环境里设置。凭据类环境变量永远赢过文件层——想临时换 key，`DEEPSEEK_API_KEY=sk-… dsh --profile blue` 即可。
+:::

--- a/website/guide/index.md
+++ b/website/guide/index.md
@@ -44,6 +44,16 @@ dsh --profile blue --resume <id>    # 恢复一个已持久化的会话
 若你的 profile 在包改名之前链过（当时包名为 `@dsh-blue/blue*`），那些链接已失效——删除 profile 目录（`~/.dsh/profiles/<name>`）或 `dsh plugin --profile <name> remove` 旧条目后重跑脚本。
 :::
 
+## 开跑前配一个 key
+
+**配一个 `DEEPSEEK_API_KEY` 就可以开始使用了**——开箱默认连 DeepSeek 官方 API（`deepseek-official` 路由，默认模型 `deepseek-v4-flash`），除 key 外无需任何配置：
+
+```sh
+export DEEPSEEK_API_KEY=sk-...        # 或写入 ~/.dsh/.credentials.yaml，一劳永逸
+```
+
+换模型、接自建网关、自定义主题等，见[配置：模型、Provider 与主题](/guide/config)。
+
 ## 首次运行
 
 ```sh


### PR DESCRIPTION
## What

A new **配置 / Configuration** page in the user manual (zh + en, both sidebars), plus a "one key before you ride" section in Quickstart (zh + en).

### The new page covers
- **Minimal path**: a single `DEEPSEEK_API_KEY` runs the out-of-the-box assembly (`deepseek-official` → `https://api.deepseek.com`, default model `deepseek-v4-flash`, thinking `high`). Key resolves **per request** — no restart after storing it, and boot/model-browsing never need it (`MISSING_CREDENTIAL` names every entry point).
- **Credential layers**: env > `~/.dsh/.credentials.yaml` > `./.env` > `~/.dsh/.env`, with the bootstrap caveat (`DEEPSEEK_BASE_URL` and every `DSH_*` var are export-only, rejected from `.env`).
- **In-app surface**: `/model` `/effort` `Alt+M`/`Alt+S`, the full `/provider` flow — panel edit form (Ctrl+D delete), add wizard's two branches (protocol/baseURL `/v1` conventions, live `GET /models` discovery, models.dev enrichment, `MY_GATEWAY_API_KEY` ref derivation), and the nothing-to-edit notice on the built-in route.
- **File layer**: `settings.yaml`'s three core sections (`agent-default-model` / `llm-deepseek` / `llm-pi-ai`) with one realistic mixed example, field-by-field override over the composition baseline, wholesale list replacement, hot-reload semantics, `.credentials.yaml` format (0600/0700, comment-preserving writes).
- **Env quick reference**: 7 user-facing variables incl. `DSH_PERMISSION_MODE` and `DSH_TELEMETRY_DISABLED`.

### Sourcing (D32 discipline)
Every claim verified against upstream rc.7/rc.8 sources (`llm-deepseek`/`llm-pi-ai`/`settings-file`/`credentials-local` READMEs + schemas, `base/cordis.patch.yml`, `app-boot` bootstrap list) and Blue's `provider-add.ts` / `model-commands.ts` / `form-panel.ts`. An exploration agent swept the whole upstream config system as a cross-check; no discrepancies against the page survived verification.

## Verification
- `pnpm run build` green (vitepress, both locales, sitemap)
- In-page anchors (`#settings-yaml-三个核心段`, `#the-three-core-settings-yaml-sections`) verified against rendered HTML
- `Ctrl+D` delete keybinding verified in `form-panel.ts` (\x04)

🤖 Generated with [Claude Code](https://claude.com/claude-code)