### PR TITLE
fix: S30 build/deploy gaps — missing tsdown entry + dev-profile loader deps

### DIFF
--- a/script/ensure-loader-entries.mjs
+++ b/script/ensure-loader-entries.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// ensure-loader-entries.mjs — keep a dsh profile bootable when the Blue
+// bundle patch references harness packages by name.
+//
+// The cordis loader imports every patch entry from the profile root, and the
+// global dsh CLI bundles only the packages dsh-base needs. Any patch entry
+// outside that closure must resolve from the profile's own node_modules or
+// boot dies with ERR_MODULE_NOT_FOUND (first hit: dsh-session-title-all-
+// prompts-llm, S30). Entries the CLI already carries are deliberately left
+// alone — installing them here as well would duplicate the module across the
+// CLI and profile stores (the S28 cross-store Symbol lesson).
+//
+// Usage: ensure-loader-entries.mjs <bundle-pkg-dir> <profile-dir> <dsh-bin>
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { createRequire } from 'node:module'
+
+const [bundleDir, profileDir, dshBin] = process.argv.slice(2)
+
+const patch = readFileSync(join(bundleDir, 'cordis.patch.yml'), 'utf8')
+const manifest = JSON.parse(readFileSync(join(bundleDir, 'package.json'), 'utf8'))
+const versions = {
+  ...manifest.dependencies,
+  ...manifest.peerDependencies,
+  ...manifest.devDependencies,
+}
+
+// Loader entries the patch names by package (`name: '@deepseek-ai/…'`),
+// pinned somewhere in the bundle manifest.
+const referenced = [...patch.matchAll(/name: '(@deepseek-ai\/[a-z0-9-]+)'/g)]
+  .map(match => match[1])
+  .filter(id => versions[id] !== undefined)
+
+// Walk up from the real dsh bin to the CLI package root (the directory whose
+// node_modules carries its bundled dependencies). A plain-name dshBin is
+// resolved through PATH first — readlink on a bare name would otherwise
+// canonicalize against the caller's cwd and probe the wrong tree.
+const onPath = dshBin.includes('/') ? dshBin : execFileSync(
+  'bash', ['-c', `command -v ${JSON.stringify(dshBin)}`], { encoding: 'utf8' },
+).trim()
+const realBin = execFileSync('readlink', ['-f', onPath], { encoding: 'utf8' }).trim()
+let cliRoot = dirname(realBin)
+for (let i = 0; i < 5 && !existsSync(join(cliRoot, 'node_modules', '@deepseek-ai')); i++) {
+  cliRoot = dirname(cliRoot)
+}
+if (!existsSync(join(cliRoot, 'node_modules', '@deepseek-ai'))) {
+  console.error(`error: could not locate the dsh CLI package root from '${realBin}' — set DSH_BIN to the dsh binary's absolute path`)
+  process.exit(1)
+}
+const cliRequire = createRequire(join(cliRoot, 'probe.cjs'))
+
+const pkgPath = join(profileDir, 'package.json')
+const profile = JSON.parse(readFileSync(pkgPath, 'utf8'))
+const added = []
+for (const id of referenced) {
+  if (profile.dependencies[id] !== undefined) continue
+  try {
+    cliRequire.resolve(id)
+    continue // the CLI bundles it; a profile copy would be a second instance
+  } catch { /* not bundled — the profile must carry it */ }
+  profile.dependencies[id] = versions[id]
+  added.push(`${id}@${versions[id]}`)
+}
+if (added.length > 0) writeFileSync(pkgPath, JSON.stringify(profile, null, 2) + '\n')
+console.log(added.length === 0
+  ? '  profile already resolves every patch loader entry'
+  : `  added to profile: ${added.join(', ')}`)

--- a/script/install-dev.sh
+++ b/script/install-dev.sh
@@ -36,6 +36,16 @@ echo "==> Link-installing Blue packages into profile '$PROFILE'"
   "link:$REPO_ROOT/packages/transcript" \
   "link:$REPO_ROOT/packages/app"
 
+# Harness packages the bundle patch references as loader entries resolve from
+# the profile root at boot; the global CLI bundles only what dsh-base needs.
+# Without this step a fresh profile boot-crashes on entries outside that
+# closure (first hit: dsh-session-title-all-prompts-llm).
+PROFILE_DIR="${DSH_HOME:-$HOME/.dsh}/profiles/$PROFILE"
+echo "==> Ensuring harness loader entries resolve from profile '$PROFILE'"
+node "$REPO_ROOT/script/ensure-loader-entries.mjs" \
+  "$REPO_ROOT/packages/bundle/blue" "$PROFILE_DIR" "$DSH_BIN"
+pnpm --dir "$PROFILE_DIR" install >/dev/null
+
 cat <<EOF
 
 Done. Blue is linked into profile '$PROFILE'.

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   workspace: {
     include: ['packages/{core,interaction,transcript,app}', 'packages/bundle/blue'],
   },
-  entry: ['lib/types/{index,invariant,chrome,startup,theme-dark,theme-light,theme-auto,theme-custom,editor-plus,status-basic,status-cwd,status-git,status-context,status-tips,pane-activity,pane-todo,pane-btw,pane-queue,attachments,paste-image,intent-diff,intent-terminal,banner,banner-content,pane-agents,mode-status}.js'],
+  entry: ['lib/types/{index,invariant,chrome,startup,theme-dark,theme-light,theme-auto,theme-custom,editor-plus,status-basic,status-cwd,status-git,status-context,status-tips,status-title,pane-activity,pane-todo,pane-btw,pane-queue,attachments,paste-image,intent-diff,intent-terminal,banner,banner-content,pane-agents,mode-status}.js'],
   outDir: 'lib',
   format: ['esm'],
   platform: 'node',


### PR DESCRIPTION
## 概要

S30①（PR #8）合并后 master 的 post-merge dogfood 在共享 `blue` profile 上 **boot 即炸**，两个缺口，CI 全绿但都测不到：

### ① tsdown 入口漏配 `status-title`（影响所有真实安装）

- 根 `tsdown.config.ts` 的 entry 是**显式枚举**；S30 给 transcript 加了 `./status-title` 导出 + patch loader 条目，但没加进清单 → `lib/status-title.js` 从未产出 → 任何 workspace 之外的安装（dsh profile）boot 死于 `ERR_MODULE_NOT_FOUND`
- **CI 盲区**：vitest 是 source-plane（spec 走 `../src/*.ts` 相对路径），从不经过 `lib/`
- 修复：入口清单补 `status-title`（一行）

### ② dev profile 缺 harness loader 依赖（影响 install-dev.sh 生成的所有新 profile）

- patch 按包名引用的 harness 包（首个：`dsh-session-title-all-prompts-llm`）由 cordis loader 从 **profile 根**解析，而全局 dsh CLI 只捆绑 dsh-base 需要的包；`dsh plugin add` 只写 link 不带运行时依赖 → 全新 profile boot 必炸（已用 throwaway profile 实证）
- 修复：`install-dev.sh` 在 link 步骤后跑 `script/ensure-loader-entries.mjs`——从 patch 提取 `@deepseek-ai/*` loader 条目、版本取自 bundle manifest，**只装 CLI 自己没捆绑的**（用 `require.resolve` 探测 CLI 包根；CLI 已有的留给 CLI，避免跨 store 双实例——S28 教训）

## 验证

- 修复后 master 上的完整 dogfood（共享 `blue` profile，真实 pty + 两轮真实对话）：S30① 全部声明通过——标题 fallback→LLM 双段生成、第二條消息重派生（自纠）、OSC 0 去重发射、footer 条目出现/消失、alt+m 三连按（含草稿中按键草稿保全、session-only notice、回绕）、/new 回退 `blue`、/sessions 切换与 resume 即时 fold
- 全新 `PROFILE=probe-fix` 从干净 checkout 走修好的 `install-dev.sh`：只补 `all-prompts-llm`（`dsh-agent-presets` 正确跳过），boot 干净、OSC `blue`
- 门禁：typecheck ✓ lint ✓ **1553 tests** ✓（worktree 全量）

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>