### PR TITLE
Fix: generic tool card bash $ command rows exceeded the viewport (pi-tui width-guard crash)

### DIFF
--- a/packages/transcript/src/components.ts
+++ b/packages/transcript/src/components.ts
@@ -363,9 +363,13 @@ export class ToolCallComponent implements BlueComponent {
         : Math.min(command.length, COMMAND_PREVIEW_LINES)
       for (let index = 0; index < cap; index += 1) {
         const body = colors.muted(command[index]!)
+        // Budgeted like every other composed row (the select-list idiom): a
+        // long one-liner command must truncate to the viewport, not reach
+        // pi-tui's width guard (the #15 family — an 186-column grep
+        // pipeline crashed the real run).
         lines.push(index === 0
-          ? `${PREVIEW_INDENT}${colors.shellMode('$ ')}${body}`
-          : `${PREVIEW_INDENT}  ${body}`)
+          ? components.truncateToWidth(`${PREVIEW_INDENT}${colors.shellMode('$ ')}${body}`, width)
+          : components.truncateToWidth(`${PREVIEW_INDENT}  ${body}`, width))
       }
     }
     if (result === undefined) return lines

--- a/packages/transcript/tests/components.spec.ts
+++ b/packages/transcript/tests/components.spec.ts
@@ -395,6 +395,20 @@ describe('ToolCallComponent', () => {
     ])
   })
 
+  it('truncates an over-wide bash command row to the viewport — the #15 family', () => {
+    // A real run crashed pi-tui's width guard on an 186-column grep pipeline
+    // (168-column terminal): the composed `$ command` row reached the
+    // renderer untruncated. Both the first row and continuations truncate.
+    const command = Array.from({ length: 24 }, () => 'very-long-segment').join(' && ')
+    const item = toolItem({ parsedArguments: { command: `${command}\n${command}` } })
+    const components = setup()
+    const rendered = new ToolCallComponent(item, COLORS, components).render(60)
+    for (const row of rendered.slice(2)) {
+      expect(components.visibleWidth(row)).toBeLessThanOrEqual(60)
+    }
+    expect(rendered[2]).toContain('...')
+  })
+
   it('caps the collapsed bash command preview and uncaps expanded', () => {
     const item = toolItem({
       parsedArguments: { command: Array.from({ length: 12 }, (_, n) => `c${n}`).join('\n') },


### PR DESCRIPTION
## 根因（pi-crash.log 实锤）

长会话崩溃 `Rendered line 223 exceeds terminal width (186 > 168)`——超宽行是 **generic ToolCallComponent 的 bash 命令预览行**（`[223] (w=186)  $ cd /home/x/... && grep ... | head -40`）：

- `components.ts` `renderBody` 拼接 `${PREVIEW_INDENT}${shellMode('$ ')}${muted(command)}` 后**直接 push，无截断**——模型跑了一条 186 列的 grep 管道命令，原样进渲染管线触发 pi-tui 宽度守卫
- 同款 idiom 缺失的第三例：#15（questionnaire）、intent-terminal/editor-plus 均已有截断（intent-terminal.ts:158、editor-plus.ts:339），唯 generic 卡的命令行漏网——#15 当时抽查的是面板非 tool 卡

## 修复

首行与续行均过 `blueComponents.truncateToWidth`（ANSI-safe，select-list 预算式 idiom）。全家扫描：components.ts 其余 push 均受控（markdown.render/wrapText 预算或恒短片段）。

## 验证

- 1618 tests / coverage 100% 逐文件 / typecheck / lint 全绿
- 新增回归用例：60 列视口渲染 400+ 列命令（首行 + 续行），逐行断言可见宽 ≤ 60 且带 `...` 截断

🤖 Generated with [Claude Code](https://claude.com/claude-code)