### PR TITLE
fix(ci): unblock the smoke step — npm -g install + register smoke:happy + de-host-depend EACCES spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,12 @@ jobs:
       # purpose: its subtree reshapes hoisting and breaks the S34 /mcp e2e's
       # bare-specifier resolution, so CI installs it globally instead and
       # the smoke pins its version against HARNESS_LINE.
-      - run: pnpm add -g @deepseek-ai/dsh@0.1.1-rc.1
+      #
+      # npm, not `pnpm add -g`: action-setup installs pnpm itself under
+      # /home/runner/setup-pnpm, and with no PNPM_HOME set `pnpm add -g`
+      # resolves the global bin dir next to the pnpm binary and refuses
+      # ("configured global bin directory ... is not in PATH" — the red
+      # run 32548149673). npm's global bin is setup-node's prefix, already
+      # on PATH for this step and for smoke:happy's `command -v dsh`.
+      - run: npm install -g @deepseek-ai/dsh@0.1.1-rc.1
       - run: pnpm smoke:happy

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "diagrams:sync": "node script/sync-diagrams.mjs",
     "diagrams:check": "node script/sync-diagrams.mjs --check",
     "check:lib": "node script/check-lib-exports.mjs",
+    "smoke:happy": "node script/smoke-happy.mjs",
     "website:dev": "pnpm --filter @dsh-blue/website run dev",
     "website:build": "pnpm --filter @dsh-blue/website run build",
     "website:preview": "pnpm --filter @dsh-blue/website run preview"

--- a/packages/interaction/tests/clipboard-write.spec.ts
+++ b/packages/interaction/tests/clipboard-write.spec.ts
@@ -188,7 +188,13 @@ describe('default clipboard text writer', () => {
     const xclip = join(bin, 'xclip')
     writeFileSync(xclip, '#!/bin/sh\nexit 0\n')
     chmodSync(xclip, 0o644)
-    prependBin(bin)
+    // Replace PATH outright, not prepend: libuv's PATH scan skips the 644
+    // (non-executable) candidates and falls through to any real wl-copy/
+    // xclip further down PATH — a desktop host has both, so a prepended
+    // bin turns the probe into the real tools (the "mixes" case below
+    // documents the same trap). Neither script execs an external command,
+    // so no PATH tail is needed.
+    process.env.PATH = bin
     await expect(copyTextToClipboard('lost'))
       .rejects.toThrow(/no clipboard tool is available \(wl-copy spawn EACCES, xclip spawn EACCES\)|wl-copy EACCES/)
     rmSync(bin, { recursive: true, force: true })


### PR DESCRIPTION
## 根因（master 红 run 32548149673）

PR #20 的 smoke 步骤至今三次全挂，两层问题叠着：

1. **`pnpm add -g @deepseek-ai/dsh@0.1.1-rc.1` 必挂**：action-setup 装的 pnpm 自身在 `/home/runner/setup-pnpm`，未设 `PNPM_HOME` 时 `pnpm add -g` 把 global bin dir 解析到 pnpm 二进制旁并直接拒绝（`The configured global bin directory ... is not in PATH`）。→ 换 `npm install -g`（setup-node 的 prefix 天然在 PATH，对后续 `smoke:happy` 的 `command -v dsh` 也可见）；HARNESS_LINE 钉版不动（R1 的 rc.2 bump 另走）。
2. **`smoke:happy` script 从未注册**：#20 加了 CI 步骤和 `script/smoke-happy.mjs`，但 root `package.json` 漏了 script 注册——一直被上一层失败掩盖，`pnpm smoke:happy` 实际报 `Command not found`。→ 补注册。

## 顺带：本机红的 clipboard EACCES spec

S26 的 `clipboard-write.spec.ts` EACCES 用例用 prepend 假 bin（644 不可执行），但 libuv 的 PATH 扫描会跳过不可执行候选、fall through 到宿主真 `wl-copy`/`xclip`——CI 的 headless runner 没装这两个工具所以一直绿，本桌面机（GNOME Wayland，两工具都有）必红（且每次等真工具 3s）。→ 改为整体替换 PATH（同文件 "mixes" 用例已示范的写法；两假件不调外部命令，无需 PATH 尾），13/13 过、3s→44ms。

## 验证

- 本地门禁全绿：typecheck / lint / diagrams:check / check:lib (36) / **1843/1843**
- `pnpm smoke:happy` 本地真跑通过（`HAPPY_SMOKE_PASS exit=0`）——这是该脚本在 anywhere 的第一次绿（PR run 将是 CI 上第一次真执行，若 runner 侧再暴露问题在此 PR 继续）
- 本 PR 的 check 若绿，master 合并后 G1 的"CI 绿"项即恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)