### PR TITLE
fix(monitor): 演练抓到管道吞码——BUMP_READY 被误判 sync，bump job 永不触发

### DIFF
--- a/.github/workflows/harness-drift.yml
+++ b/.github/workflows/harness-drift.yml
@@ -72,8 +72,13 @@ jobs:
           node-version: ${{ env.PRIMARY_NODE_VERSION }}
       - id: classify
         run: |
+          # Capture the exit code WITHOUT a pipeline: the default shell has
+          # no pipefail, so `node | tee || code=$?` reads tee's 0 and turns
+          # a BUMP_READY (10) into a bogus sync (caught in the first
+          # apply rehearsal — run 32561189281).
           code=0
-          node script/harness-drift.mjs | tee drift-report.txt || code=$?
+          node script/harness-drift.mjs > drift-report.txt || code=$?
+          cat drift-report.txt
           case "$code" in
             0) state=sync ;;
             10) state=bump-ready ;;


### PR DESCRIPTION
## Bug（首个 apply 演练 run 32561189281 抓到）

classify 步骤的 \`node script/harness-drift.mjs | tee drift-report.txt || code=$?\`：GitHub 默认 shell 无 pipefail，\`||\` 读到的是 **tee 的退出码 0**——脚本 exit 10（BUMP_READY）被吞成 \`code=0\`，同一步里打印着 \`detect: state=sync current=0.1.1-rc.1 target=0.1.1-rc.2\` 的自相矛盾，bump job 被错误 skip。**不修的话监控永远只会 detect，不会 bump。**

## 修法

先重定向到文件再 cat，退出码不经管道：

\`\`\`bash
code=0
node script/harness-drift.mjs > drift-report.txt || code=$?
cat drift-report.txt
\`\`\`

合并后我会重跑 apply 演练（rehearsal/drift-apply 分支已在位）验证 BUMP_READY → agent → 门禁 → 自动 PR 全链路。

🤖 Generated with [Claude Code](https://claude.com/claude-code)