### PR TITLE
fix(monitor): alert job 的 gh 调用补 repo 上下文（无 checkout 时 gh 找不到 git 仓）

### DIFF
--- a/.github/workflows/harness-drift.yml
+++ b/.github/workflows/harness-drift.yml
@@ -163,6 +163,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
+      # No checkout in this job: every gh call carries the repo explicitly
+      # (without a git context gh fails with "not a git repository").
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Upsert the drift tracking issue
         run: |


### PR DESCRIPTION
首个 apply 演练（run 32561521323）中 alert job 因无 checkout 且 gh 未带 repo 参数而挂——`fatal: not a git repository`。GH_REPO env 显式携带仓库，issue upsert 不再依赖 git 上下文。

另：同一次演练证实 bump 链路（agent → 门禁 → push automation 分支）已全绿，最后一步 `gh pr create` 需要仓库设置开启 "Allow GitHub Actions to create and approve pull requests"（Settings → Actions → General → Workflow permissions）——这是仓库级开关，workflow 侧无法自开。

🤖 Generated with [Claude Code](https://claude.com/claude-code)