### PR TITLE
docs: define Blue frontend architecture and migration plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,13 @@
 | [blue-editor-walkthrough.md](./blue-editor-walkthrough.md) | Editor 缝实例走查：契约/实现/消费/增强四角色逐层走查（自 README 抽出全文） |
 | [blue-decisions.md](./blue-decisions.md) | ADR 决策记录（D1-D38，按主题分组，编号稳定不回收） |
 | [blue-commands-plan.md](./blue-commands-plan.md) | 内置命令实施清单：四家参照系合并、能力支撑矩阵、S23-S29 分期（S29 待实施；§1.3 是 p1-design §4.3 判定的更正正典） |
+| [blue-frontend-architecture.md](./blue-frontend-architecture.md) | 新目标架构：Harness domain、frontend runtime、TUI kernel 与 renderer 的边界 |
+| [blue-session-runtime.md](./blue-session-runtime.md) | projection、action、session binding 与兼容 adapter 的目标职责 |
+| [blue-interaction-model.md](./blue-interaction-model.md) | 不绑定 renderer 的 command、panel、status、dock 与 provider 模型 |
+| [blue-plugin-ecosystem.md](./blue-plugin-ecosystem.md) | 外部插件分类、bundle/profile 安装与运行时热插拔 |
+| [blue-compatibility-and-rollout.md](./blue-compatibility-and-rollout.md) | 主分支演进、Harness 兼容窗口、新旧实现共存与迁移门禁 |
+| [blue-fixture-audit.md](./blue-fixture-audit.md) | dsh-remote、dsh-context、dsh-openpencil、dsh-lark 的迁移审计与验证计划 |
+| [blue-skills-plan.md](./blue-skills-plan.md) | 插件开发与迁移 skills 的输入、诊断输出和实施顺序 |
 
 图源约定：架构分层与 bundle 组合两张 mermaid 图的单一来源在 [diagrams/](./diagrams/)（`.mmd`）；README（中英）与 blue-architecture.md 中的嵌入块由 `pnpm run diagrams:sync` 生成，CI 以 `pnpm run diagrams:check` 把关一致性——改图请改 `.mmd` 源，不要手改嵌入块。
 

--- a/docs/blue-api-design.md
+++ b/docs/blue-api-design.md
@@ -1,5 +1,7 @@
 # Blue API Foundation
 
+> **目标架构迁移说明（2026-08）**：本文记录 PR 23/35 的 API foundation、host 和生命周期阶段，不再是后续前端重构的唯一目标。新的 Domain/Interaction/Renderer/Composition 边界见 [blue-frontend-architecture.md](./blue-frontend-architecture.md)，session runtime 见 [blue-session-runtime.md](./blue-session-runtime.md)。本文中的 host/contract 仍是现有实现和兼容迁移的参考。
+
 This implementation starts the stable API work described by PR 23
 (`0769e068`). `@dsh-blue/blue-api` is a leaf package: it owns readonly,
 renderer-independent contracts and manifest validation, while Cordis remains

--- a/docs/blue-architecture.md
+++ b/docs/blue-architecture.md
@@ -3,6 +3,8 @@
 > 姊妹文档：[blue-roadmap.md](./blue-roadmap.md)（分阶段路线图）、[blue-mvp-plan.md](./history/blue-mvp-plan.md)（MVP 实施计划）、[blue-p1-design.md](./history/blue-p1-design.md)（P1 层职责定稿与缝清单）
 > 本文档是 Blue 的架构蓝图：可行性结论、分层设计、核心契约、稳定性机制。代码现状以仓库 `AGENTS.md` 为准。
 
+> **目标架构说明（2026-08）**：跨 renderer 的新目标架构、Domain/Interaction/Renderer/Composition 分层、session runtime 和 provider 热插拔以 [blue-frontend-architecture.md](./blue-frontend-architecture.md) 及其姊妹文档为准。本文保留已落地 Blue TUI 的历史分层和当前实现参考，不代表重构后的最终包边界。
+
 ## 1. 背景与可行性结论
 
 Blue 是 deepseek-harness（`dsh`）的交互式终端 UI，基于 `@earendil-works/pi-tui` 渲染，按 harness 的 Cordis 插件哲学组织。可行性的三条事实依据：

--- a/docs/blue-compatibility-and-rollout.md
+++ b/docs/blue-compatibility-and-rollout.md
@@ -1,0 +1,29 @@
+# Blue Compatibility And Rollout
+
+## Harness 兼容策略
+
+Blue 主线按当前钉版开发，并保留上一条 Harness 线的 contract fixture。新功能只消费官方 API；缺能力时增加独立窄 adapter，不修改 Blue 核心以适配某个版本。
+
+能力探测优先于版本号分支。版本信息集中在 adapter；frontend feature 只看到 capability present/absent。
+
+每个 adapter 文档必须写出删除条件，例如“上游 session projection 覆盖 resume watermark 后删除 session bridge”。adapter 不维护第二套业务状态，不暴露 Agent/Session 原对象，不使用 package-internal import。
+
+## 新旧实现共存
+
+旧实现保留为 golden/e2e 行为基线。迁移按 vertical slice 进行：domain/adapter、projection/action、interaction model、TUI renderer、headless fixture、unload/width 测试齐全后，才切换 bundle row。
+
+provider host 永存；旧 provider 可以卸载，新 provider 立即挂载，失败回退 plain provider。旧代码不得通过非公开 shortcut 绕过新 host。
+
+## 主分支演进
+
+重构分支定期从 master 更新，避免长期 fork。Harness 新增官方能力时按 additive 路径接入：新增 adapter、feature plugin、bundle row 和 fixture，不修改已有 kernel contract。每次 harness line 升级都运行当前线与上一线 contract fixture、全量 Blue gate、真实 profile smoke。
+
+## 阶段门禁
+
+1. 文档与现状索引同步；
+2. 独立外部 fixture 能加载并卸载；
+3. projection replay/resume、action abort/stale rejection 通过；
+4. provider swap/fallback 通过；
+5. headless/TUI composition 和 width-scan 通过；
+6. 真实安装、PTY smoke 和用户 dogfood 通过后才替换官方 surface。
+

--- a/docs/blue-fixture-audit.md
+++ b/docs/blue-fixture-audit.md
@@ -1,0 +1,25 @@
+# External Fixture Audit
+
+本文记录外部插件如何验证 Blue 目标架构；不把“可迁移”误写成“已迁移”。
+
+## [dsh-remote](https://github.com/GeekCmore/dsh-remote)
+
+`dsh-remote` 已按 shared core、backend、client、proxy、frontend、bundle 拆分，提供 live/daemon 两种模式、capability negotiation、seq-cursor resume、write lease、approval/question bridge 和 daemon-TUI bundle。
+
+验证重点：session runtime、attach/detach、remote proxy、action 转发、多 session scope、headless 与 TUI 共用 domain 能力。它应作为第二条垂直 fixture，而不是第一个 UI 迁移样例。
+
+## [dsh-context](https://github.com/bowenliang123/dsh-context)
+
+验证链路：Harness context/token-meter domain -> projection -> `/context` command/action -> panel/status interaction model -> Blue TUI renderer。重点检查 replay/resume、projection watermark、缺能力降级、Fiber unload、窄终端和 fixture snapshot。
+
+## [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil)
+
+Domain 包含工具、签名 capability、事务性 batch action 和文件生命周期；交互/renderer 包含多帧预览、Web canvas 和 managed editor。Blue 迁移目标是提供文本/摘要 fallback，不复制 Web canvas；headless domain 能力必须独立可用。
+
+## [dsh-lark](https://github.com/sugarforever/dsh-lark)
+
+验证外部系统 action、notification、credentials/config 和无 TUI domain 使用。Blue adapter 只负责将结果映射到 command/notification model。
+
+## 统一审计字段
+
+后续每个 fixture 都记录 Domain、Projection、Action、Command、Interaction model、Renderer-specific UI、Bundle rows、scope、依赖、迁移风险和验证场景。

--- a/docs/blue-frontend-architecture.md
+++ b/docs/blue-frontend-architecture.md
@@ -1,0 +1,76 @@
+# Blue 前端目标架构
+
+> 状态：目标架构，2026-08。本文描述重构后的边界，不把尚未迁移的代码写成现状。当前实现仍以 `blue-architecture.md`、`blue-seams.md` 和包级 `AGENTS.md` 为准。
+
+## 目标
+
+Blue 负责把 Harness 的 Agent 能力变成可替换、可维护的交互式前端。TUI 是第一种 renderer，但不是 Agent 能力的所有者；同一 domain 插件应能在 TUI、Web 或 headless 环境复用。
+
+```text
+Harness domain -> Blue frontend runtime -> renderer adapter -> terminal/DOM
+```
+
+Harness 继续拥有 Agent、Session、工具、持久化、权限、模型路由和公开事件/服务。Blue 不维护第二套 Agent 真相，只提供 renderer-neutral interaction model、TUI kernel 和组合层。
+
+## 四类插件
+
+| 类型 | 拥有 | 依赖 | 例子 |
+|---|---|---|---|
+| Domain | service、tool、projection、action、业务 command | Harness | context、remote、OpenPencil domain |
+| Interaction | command/panel/status/dock/provider model | Harness domain + `blue-frontend` | `/context`、model selector |
+| Renderer | layout、focus、input、视觉呈现 | frontend model + renderer kernel | Blue TUI |
+| Composition | bundle、preset、启停、重排 | Cordis Loader | `cordis.patch.yml` |
+
+官方包可以暂时把多个类型放在一个仓库，但公共契约和 Fiber 所有权必须按类型分开。
+
+## Scope 规则
+
+- **host**：跨 session 的 registry/service，例如模型、凭据、MCP、subagent 查询。
+- **agent**：一个 Agent 拥有的 tools、persona、prompt 和 preset 组合。
+- **session**：一个持久化 session 的 projection 和 action 状态。
+- **frontend tree**：当前选中 session、draft、focus、panel stack 和 active provider。
+- **provider Fiber**：provider 自己的订阅、timer、缓存和异步任务。
+
+产品级可变状态不得放在模块 singleton。renderer 对象不得进入 host/session scope；frontend binding 不能成为 session 事实来源。
+
+## TUI Kernel 边界
+
+`blue-core` 仍是唯一接触 pi-tui 和 raw terminal 的包，拥有 terminal lifecycle、frame scheduling、width truth、layout、focus、key routing、overlay/editor slot、theme 编译和 render error boundary。
+
+Kernel 不知道 Agent、SessionEvent、工具语义或命令业务。插件贡献 readonly model 和 action，而不是 pi-tui component。现有 `blueScreen`、`blueKeymap`、`blueComponents` 可作为内部 TUI kernel seam；公共 frontend API 不透传这些类型。
+
+## 目标包形态
+
+```text
+@dsh-blue/blue-api
+  通用 manifest、BlueResult、基础 readonly 数据
+
+@dsh-blue/blue-frontend
+  interaction model、frontend host、provider contract
+
+@dsh-blue/blue-core
+  TUI kernel 与 pi-tui adapter
+
+blue-harness-adapter
+  独立、按能力拆分的 Harness -> Blue 兼容插件
+```
+
+`blue-frontend` 首期属于 Extension/Internal，不立即承诺 Stable v1；经过外部 fixture、卸载、替换和双版本兼容验证后再冻结。
+
+## 数据流
+
+```text
+Harness event/service
+  -> adapter 或原生 projection
+  -> session projection/action runtime
+  -> interaction model
+  -> TUI renderer
+  -> requestRender()
+```
+
+UI 不直接折叠 Harness event。事件表达事实，projection 表达当前状态，action 表达带结果的写请求。
+
+## 迁移纪律
+
+旧实现先保留为行为基线；新实现按 vertical slice 接入。一个 slice 必须同时有 domain/adapter、interaction model、TUI renderer、headless fixture、unload 测试和现有 golden/e2e 对比，之后才能替换旧 provider。
+

--- a/docs/blue-interaction-model.md
+++ b/docs/blue-interaction-model.md
@@ -1,0 +1,32 @@
+# Blue Interaction Model
+
+> Renderer-neutral 交互协议。本文不实现 Web，也不把 pi-tui 类型变成公共 API；Blue 当前只提供 TUI renderer。
+
+## 分层
+
+```text
+Domain data       TodoItem / ToolRun / ModelInfo / ContextUsage
+Interaction model Command / Panel / Status / Dock / Notification
+Renderer model    pi-tui component / React element / DOM / ANSI rows
+```
+
+共享 frontend model 只到第二层。它是 readonly 数据和结构化动作描述，不包含 focus handle、terminal width、ANSI、React ref、键位解释或 Promise。
+
+## 首批模型
+
+- `TextView`、`RichTextView`、`FieldsView`、`SectionsView`、`ListView`、`CodeView`、`DiffView`；
+- `CommandModel`：名称、描述、参数 schema、可用状态、执行 action；
+- `PanelModel`：select、form、info、loading、error、submit/cancel action；
+- `StatusModel`：纯文本/字段、优先级、band、可见条件；
+- `DockModel`：placement、优先级、建议行数、折叠状态和 view；
+- `NotificationModel`：severity、plain message、duration、dedupe key；
+- `ProviderModel`：provider id、capabilities、可迁移的 renderer-neutral state。
+
+TUI renderer 负责布局、输入、焦点、宽度、主题和 fallback。模型提交 action 后由 domain/action runtime 执行，结果再通过 projection 或 notification 回流。
+
+## Provider 替换
+
+provider host 持续存活；替换流程为 `capture -> abort -> dispose -> activate -> restore`。provider 不得拒绝卸载；状态迁移 best-effort；激活失败回退 plain provider，只影响该 surface，不影响 Agent loop。
+
+Editor、theme、transcript 和主 panel provider 使用同一生命周期规则，但各自拥有窄 contract，不合并成万能 provider。
+

--- a/docs/blue-plugin-ecosystem.md
+++ b/docs/blue-plugin-ecosystem.md
@@ -1,0 +1,38 @@
+# Blue Plugin Ecosystem
+
+## 安装与激活
+
+Harness 的用户路径分三步：安装 npm 包、profile 记录 bundle、Cordis patch 挂载 rows。
+
+```sh
+dsh plugin --profile blue add <package>
+```
+
+没有 `dsh.bundle` 的包只会作为普通依赖安装，不会自动激活。bundle 的 `cordis.patch.yml` 才声明 plugin rows、`name`、`inject` 和 config。
+
+```text
+bundles -> profile cordis.patch.yml -> home patch -> --patch
+```
+
+上层按 row id 覆盖、禁用或插入新实现；这是启动期 composition。运行时 provider 切换由 Blue provider host 和 command 完成，不要求用户修改 patch 后重启。
+
+## 跨 frontend 发布
+
+一个功能优先拆成：
+
+```text
+@scope/feature        Domain bundle，headless/Web/TUI 共用
+@scope/feature-blue   Blue TUI adapter bundle，可选
+@scope/feature-web    其他 renderer adapter，可选
+```
+
+Domain bundle 不注入 Blue 服务；Blue adapter bundle 才注入 `blue-frontend`/TUI services，避免 headless profile 因缺少 renderer 服务而 pending。
+
+## Cordis 纪律
+
+每个插件导出稳定 `name`、最窄 `inject` 和 `apply(ctx)`；所有 registry、event、timer、subscription、mounted model 都用 `ctx.effect` 绑定 Fiber。插件不得 import pi-tui 或 Blue 内部文件。卸载必须回收贡献、异步任务、panel、focus 和 cache。
+
+## Capability 与降级
+
+能力不存在是正常状态：没有 projection 则不显示对应 surface，没有 renderer 则提供 plain fallback，没有 action 则禁用提交。插件错误只影响自身 contribution；provider 激活失败回退 plain provider。
+

--- a/docs/blue-session-runtime.md
+++ b/docs/blue-session-runtime.md
@@ -1,0 +1,32 @@
+# Blue Session Runtime
+
+> 目标职责文档。Harness 已有的原生 projection/action 优先消费；Blue 只在缺失时挂载独立兼容 adapter。
+
+## 三个服务
+
+### Projection Runtime
+
+Domain plugin 注册纯同步 projection unit：`init`、`apply`、schema、stateVersion，以及可选的 client view。registry 统一订阅一次 `session/event`，按 session 保存 state，生成 whole-value snapshot 和带 seq 的 change feed。
+
+不关心事件时返回同一 state reference；注册 Fiber 卸载时移除 key 和缓存。未注册 key 表示 capability absent，不是异常。
+
+### Action Coordinator
+
+统一承载 `followup`、`steer`、`interrupt`、`new`、`resume`、`fork` 和领域 action。每个 action 有 session scope、request/session epoch、AbortSignal、排队、结构化 `BlueResult` 和 stale-result 拒绝。
+
+事件只通知已提交事实；action 不用无返回值 event 伪装。session switch 必须先成功创建、再提交 current binding、最后发布变更事件。
+
+### Frontend Session Binding
+
+TUI 选择一个 current session，Web 可以同时观察多个 session，headless 显式指定 session。binding 不拥有 Agent/Session，只引用 runtime 的 snapshot/action façade。
+
+## 兼容 adapter
+
+adapter 是 anti-corruption layer，只做三件事：把 Harness 官方 API 转成 Blue 最小事实、把 Blue action 转回官方 action、集中处理版本差异和 capability probing。
+
+adapter 按能力拆成独立 Cordis plugin，例如 session bridge、model bridge、projection bridge、question bridge。每个 adapter 记录删除条件，不暴露 raw Agent/Session，不依赖 package-internal API。
+
+## 生命周期
+
+session attach 时先建立 snapshot watermark，再订阅增量；只接受 watermark 之后的事件。detach/switch 先 abort action、停止订阅和 timer，再移除 session-scoped cache。late event/result 只能被丢弃或转为诊断，不能重新挂载 UI。
+

--- a/docs/blue-skills-plan.md
+++ b/docs/blue-skills-plan.md
@@ -1,0 +1,18 @@
+# Plugin Development And Migration Skills
+
+## Plugin Development Skill
+
+引导开发者先判定插件类型（Domain、Interaction、Renderer、Composition）和 scope（host、agent、session、frontend tree），再选择 service、registry、projection、action 或 provider。输出 package/bundle 拆分、Cordis rows、inject、capability、fallback、unload 和测试清单。
+
+## Plugin Migration Skill
+
+扫描现有插件的 pi-tui/React/DOM import、Agent/Session 直接访问、自行折叠 session event、module singleton、Web/domain 混合、bundle 隐含依赖和缺失 lifecycle 测试。输出可复用 Domain、待抽取 Interaction、renderer-specific 部分、所需 Blue adapter、拆包建议和风险。
+
+## Plugin Fixture Skill
+
+生成 headless、TUI、provider swap、unload、projection replay、action abort 和 width-scan 测试骨架。fixture 必须从独立安装包或 link bundle 加载，不能只从 Blue workspace 相对 import。
+
+## 实施顺序
+
+先用 `dsh-context` 迁移过程验证分类和诊断，再实现生成模板；用 `dsh-remote` 验证 session/remote adapter，最后用 `dsh-openpencil` 验证 renderer capability/fallback。
+


### PR DESCRIPTION
## Summary

- define the target Domain / Interaction / Renderer / Composition architecture
- specify session projection/action runtime and narrow Harness compatibility adapters
- document frontend-neutral interaction models, Cordis bundle/profile activation, and provider hot swap
- audit external fixtures: dsh-remote, dsh-context, dsh-openpencil, and dsh-lark
- specify plugin development, migration, and fixture skills

## Supersedes

- Supersedes the target architecture direction in #23. The original audit and API foundation remain historical references.
- Supersedes the remaining documentation direction in #35. Its implementation commits are already present on master.

## Verification

- `pnpm run diagrams:check`
- `git diff --check`
- Markdown fence and relative-doc-link checks

Docs-only change; no runtime or package behavior is modified.