### PR TITLE
fix(bundle): mount cordis-host-runner so the cordis preset activates

### DIFF
--- a/packages/bundle/blue/AGENTS.md
+++ b/packages/bundle/blue/AGENTS.md
@@ -22,8 +22,9 @@ Two parts:
 
 1. The upstream `agent-presets` roster row sits at the head of the insert block — the dsh CLI launcher keys on the row id to inject the shipped preset root; Blue never resolves preset paths.
 2. Ahead of the insert, the web-app bundle's own ruling is ported row-for-row: twenty-three dsh-base agent-plane rows disabled (`tool-*`, plan-mode, the compaction trio, the delegation four, the workflow trio, `agent-instructions`; `tool-subagent-report` and `system-prompt` stay host-plane), which moves the agent plane behind the presets and gives `/preset` true replacement semantics.
+3. The host-plane `cordis-host-runner` row (also the web-app's own ruling — dsh-base mounts no provider) supplies `dynamicCordisRunner` + `cordisInspect`, the inject of the shipped `cordis` preset's `tool-cordis` row; without it that preset's standing mount fails the roster's activation audit. The web client's half (`cordis-client-runner`) is deliberately not ported.
 
-`bundle.spec.ts` pins the disable list to the web-app's (drift guard) and asserts every id addresses a real base row. The runtime dependency `@deepseek-ai/dsh-agent-presets` rides the bundle's `dependencies` so `dsh plugin add` installs it.
+`bundle.spec.ts` pins the disable list to the web-app's (drift guard) and asserts every id addresses a real base row. The runtime dependencies `@deepseek-ai/dsh-agent-presets` and `@deepseek-ai/dsh-cordis-host-runner` ride the bundle's `dependencies` so `dsh plugin add` installs them.
 
 ## Distribution contract
 

--- a/packages/bundle/blue/cordis.patch.yml
+++ b/packages/bundle/blue/cordis.patch.yml
@@ -132,6 +132,18 @@
       config:
         default: standard
 
+    # The dynamic-cordis host runner, host plane, mirroring the web-app
+    # bundle's own `cordis-host-runner` row: one plugin providing both
+    # `dynamicCordisRunner` and `cordisInspect` — the services the shipped
+    # `cordis` preset's `tool-cordis` row declares in its inject. dsh-base
+    # never mounts a provider for them, so without this row that preset's
+    # standing mount parks `tool-cordis` waiting forever and the roster's
+    # activation audit fails the `/preset cordis` switch ("1 row(s) did not
+    # activate"). A terminal host needs only this half; the web-app's
+    # `cordis-client-runner` row is the browser client's half.
+    - id: cordis-host-runner
+      name: '@deepseek-ai/dsh-cordis-host-runner'
+
     # The all-prompts half of the session-title cadence swap above: the
     # same auxiliary-model title policy as the base's first-prompt row
     # (words/bytes/token/timeout values copied verbatim), registering the

--- a/packages/bundle/blue/package.json
+++ b/packages/bundle/blue/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@dsh-blue/blue-api": "workspace:*",
     "@deepseek-ai/dsh-agent-presets": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-cordis-host-runner": "0.1.1-rc.2",
     "@deepseek-ai/dsh-mcp-client": "0.1.1-rc.2",
     "@deepseek-ai/dsh-session-title-all-prompts-llm": "0.1.1-rc.2",
     "@dsh-blue/blue-app": "workspace:*",

--- a/packages/bundle/blue/tests/bundle.spec.ts
+++ b/packages/bundle/blue/tests/bundle.spec.ts
@@ -104,6 +104,22 @@ describe('blue bundle', () => {
     expect(patch.indexOf('- id: agent-presets')).toBeLessThan(patch.indexOf('- id: blue-core'))
   })
 
+  it('inserts the cordis host-runner row the shipped cordis preset\'s tool-cordis injects', () => {
+    // Host plane, mirroring the web-app bundle's own row: the runner provides
+    // `dynamicCordisRunner` + `cordisInspect`, without which the `cordis`
+    // preset's standing mount parks `tool-cordis` and the roster's activation
+    // audit fails the `/preset cordis` switch.
+    expect(patch).toContain('- id: cordis-host-runner')
+    expect(patch).toContain("name: '@deepseek-ai/dsh-cordis-host-runner'")
+    expect(patch.indexOf('- id: cordis-host-runner')).toBeLessThan(patch.indexOf('- id: blue-core'))
+    // The package must install with the bundle (dsh plugin add), exactly as
+    // the agent-presets roster's own runtime dependency rides it.
+    const manifest = JSON.parse(readFileSync(join(patchDir, '..', 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>
+    }
+    expect(manifest.dependencies?.['@deepseek-ai/dsh-cordis-host-runner']).toBeDefined()
+  })
+
   it('disables exactly the web-app bundle\'s thin-host agent-plane list, every id addressing a real base row', () => {
     // The thin-host migration mirrors the harness's own ruling: the set of
     // rows the web-app bundle disables must equal Blue's, so when the base

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@deepseek-ai/dsh-agent-presets':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(458d8f960a6e445302dd5b0902b079dd)
+      '@deepseek-ai/dsh-cordis-host-runner':
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(d57c446fab7b15594d84254941d4f4c8)
       '@deepseek-ai/dsh-mcp-client':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(8c2a11b378cd5cf327104574f6e069b2)


### PR DESCRIPTION
## 问题

`/preset` 选择 **创造模式(cordis)** 报错:

```
agent-presets: preset "cordis" failed to mount: 1 row(s) did not activate:
tool-cordis (@deepseek-ai/dsh-tool-cordis): waiting for dynamicCordisRunner, cordisInspect
```

## 根因

shipped `cordis` preset 的 `tool-cordis` 行声明 `inject: ['tools', 'dynamicCordisRunner', 'cordisInspect']`。后两个服务由 `@deepseek-ai/dsh-cordis-host-runner` 一个插件同时提供(host plane)。`dsh-base` 不挂载它;官方挂载方是 web-app bundle 的 `cordis-host-runner` 行。Blue 在 thin-host 迁移(S28/D37)时只逐行移植了 web-app 的 **agent-plane disable 列表**,没有跟移植这个 **host-plane** 行,于是 Blue 组合里没有任何 fiber 提供这两个服务,`tool-cordis` 的 fiber 永远停在等待态,roster 的激活审计直接让挂载失败。其余三个 shipped preset(standard/code/minimal)不含 `tool-cordis`,所以只有创造模式受影响。

## 修复

- `cordis.patch.yml`:insert 段头部(`agent-presets` 之后)补 host-plane 的 `cordis-host-runner` 行,镜像 web-app 的裁决;浏览器侧的 `cordis-client-runner` 行刻意不移植。
- `packages/bundle/blue/package.json`:`@deepseek-ai/dsh-cordis-host-runner` 以 harness 线精确 pin 进 `dependencies`,随 `dsh plugin add` 安装(与 `dsh-agent-presets` 同一先例)。
- `bundle.spec.ts`:新增断言钉住该行及其依赖声明。
- bundle `AGENTS.md`:thin-host 一节补第三条。

## 验证

- `pnpm run test` / `test:coverage`(per-file 100%)/ `typecheck` / `lint` / `check:lib` / `check:pack` 全绿。
- Dogfood(profile `blue-cordis-host-runner`,link 安装自本 worktree):
  - 伪 TTY 冒烟:`/preset cordis` 切换成功,无 `failed to mount`;会话日志确认写入 `agent-preset/selected: cordis`;bracketed-paste 开/关正常,退出码 0。
  - `--resume` 重启该 preset 会话:同样干净。
  - 真人验收:`dsh --profile blue-cordis-host-runner` 下切创造模式通过。
