### PR TITLE
feat(website): launch the plugin marketplace

### DIFF
--- a/.github/workflows/website-pages.yml
+++ b/.github/workflows/website-pages.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - .github/workflows/website-pages.yml
       - website/**
+      - script/marketplace-fetch.mjs
       - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
@@ -17,9 +18,14 @@ on:
     paths:
       - .github/workflows/website-pages.yml
       - website/**
+      - script/marketplace-fetch.mjs
       - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
+  # 每日重建：marketplace 仓的收录合并不会触发本仓 workflow，市场的更新
+  # （以及坏数据的暴露）最迟滞后到下一次定时构建；Pages 保留最后一个好产物。
+  schedule:
+    - cron: '17 3 * * *'
   workflow_dispatch:
 
 permissions:
@@ -47,6 +53,8 @@ jobs:
           node-version: ${{ env.PRIMARY_NODE_VERSION }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # 严格模式：拿不到市场数据直接 fail——绝不部署一个渲染成“暂无收录”的空市场。
+      - run: node script/marketplace-fetch.mjs
       - run: pnpm --filter @dsh-blue/website run build
 
   build:
@@ -66,6 +74,8 @@ jobs:
           node-version: ${{ env.PRIMARY_NODE_VERSION }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # 严格模式：拿不到市场数据直接 fail——绝不部署一个渲染成“暂无收录”的空市场。
+      - run: node script/marketplace-fetch.mjs
       - uses: actions/configure-pages@v6
         id: pages
       - run: pnpm --filter @dsh-blue/website run build

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ coverage/
 website/.vitepress/dist/
 website/.vitepress/cache/
 .claude/tmp/
+.marketplace-cache/
+website/.vitepress/marketplace-data/
+website/marketplace/*/
+website/en/marketplace/*/

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
     "blue:plugin-fixture": "node script/blue-plugin-fixture.mjs",
     "fixture:context-upstream": "node script/context-upstream-fixture.mjs",
     "fixture:remote-upstream": "node script/remote-upstream-fixture.mjs",
-    "website:dev": "pnpm --filter @dsh-blue/website run dev",
-    "website:build": "pnpm --filter @dsh-blue/website run build",
-    "website:preview": "pnpm --filter @dsh-blue/website run preview"
+    "website:dev": "node script/marketplace-fetch.mjs --allow-missing && pnpm --filter @dsh-blue/website run dev",
+    "website:build": "node script/marketplace-fetch.mjs && pnpm --filter @dsh-blue/website run build",
+    "website:preview": "pnpm --filter @dsh-blue/website run preview",
+    "marketplace:fetch": "node script/marketplace-fetch.mjs"
   },
   "devDependencies": {
     "@deepseek-ai/dsh-llm-mock-server": "0.1.1-rc.2",

--- a/script/marketplace-fetch.mjs
+++ b/script/marketplace-fetch.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// 从 dsh-blue/marketplace 拉取插件市场数据，拷贝为网站的 untracked 生成物：
+//   registry.json / categories.json      → website/.vitepress/marketplace-data/
+//   content/<id>/zh.md                   → website/marketplace/<id>/index.md
+//   content/<id>/en.md                   → website/en/marketplace/<id>/index.md
+//   content/<id>/assets/**               → 两侧同名 assets/
+// 手写的 website/marketplace/index.md、submit.md 永不触碰；仅按 manifest
+// 清理上一轮生成的插件目录（防下架插件残留成死路由）。
+//
+// 用法：node script/marketplace-fetch.mjs [--ref <ref>] [--allow-missing] [--force]
+//   --ref           marketplace 仓库的分支/标签，默认 master
+//   --allow-missing 拿不到数据时不报错（本地 dev 降级用；CI 不带此参数）
+//   --force         忽略缓存重新 clone
+// 环境变量 MARKETPLACE_REPO 可覆盖源（默认 GitHub；本地联调指向本地路径）。
+import { spawnSync } from 'node:child_process'
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const SRC = process.env.MARKETPLACE_REPO ?? 'https://github.com/dsh-blue/marketplace.git'
+const CACHE = join(repoRoot, '.marketplace-cache')
+const DATA_DIR = join(repoRoot, 'website/.vitepress/marketplace-data')
+const SIDES = [
+  { lang: 'zh', base: join(repoRoot, 'website/marketplace') },
+  { lang: 'en', base: join(repoRoot, 'website/en/marketplace') },
+]
+const MANIFEST = join(DATA_DIR, '.generated.json')
+// 与网站手写页面冲突的保留 id（marketplace 仓校验脚本同款清单）
+const RESERVED = new Set(['submit'])
+
+const args = process.argv.slice(2)
+const flag = (name) => args.includes(name)
+const opt = (name) => {
+  const i = args.indexOf(name)
+  return i >= 0 ? args[i + 1] : undefined
+}
+const REF = opt('--ref') ?? 'master'
+const ALLOW_MISSING = flag('--allow-missing')
+
+const fail = (msg) => { console.error(`✖ marketplace-fetch：${msg}`); process.exit(1) }
+const git = (args_, opts = {}) => spawnSync('git', args_, { encoding: 'utf8', ...opts })
+// git 的 stderr 首行常是 "Cloning into '.'..." 之类的噪音，取最后一条实质信息
+const lastLine = (s) => (s || '').trim().split('\n').filter(Boolean).pop() ?? ''
+
+// ── 1. 取数：clone / fetch，失败时降级用旧缓存 ──────────────────────────────
+if (flag('--force') && existsSync(CACHE)) rmSync(CACHE, { recursive: true, force: true })
+
+const cacheHasData = () => existsSync(join(CACHE, 'registry.json'))
+
+if (!cacheHasData()) {
+  mkdirSync(CACHE, { recursive: true })
+  const r = git(['clone', '--depth', '1', '--branch', REF, SRC, '.'], { cwd: CACHE })
+  if (r.status !== 0) {
+    rmSync(CACHE, { recursive: true, force: true })
+    if (ALLOW_MISSING) {
+      console.warn('⚠ marketplace-fetch：无法获取数据（--allow-missing，跳过）')
+      process.exit(0)
+    }
+    fail(`clone ${SRC}@${REF} 失败：${lastLine(r.stderr) || lastLine(r.stdout)}`)
+  }
+} else {
+  const fetch = git(['fetch', '--depth', '1', 'origin', REF], { cwd: CACHE })
+  const reset = fetch.status === 0 ? git(['reset', '--hard', 'FETCH_HEAD'], { cwd: CACHE }) : fetch
+  if (reset.status !== 0) {
+    if (cacheHasData()) console.warn(`⚠ marketplace-fetch：更新失败，沿用缓存（${(fetch.stderr || '').trim().split('\n').pop()}）`)
+    else if (ALLOW_MISSING) { console.warn('⚠ marketplace-fetch：缓存无效且无法获取数据（--allow-missing，跳过）'); process.exit(0) }
+    else fail(`fetch ${SRC}@${REF} 失败：${(fetch.stderr || '').split('\n')[0]}`)
+  }
+}
+
+// ── 2. 交叉校验（拷贝前全查一遍，杜绝半拷贝）───────────────────────────────
+const errors = []
+let registry
+try {
+  registry = JSON.parse(readFileSync(join(CACHE, 'registry.json'), 'utf8'))
+} catch (e) {
+  errors.push(`registry.json 无法解析：${e.message}`)
+}
+const plugins = Array.isArray(registry?.plugins) ? registry.plugins : []
+if (!plugins.length) errors.push('registry.json 中没有任何插件条目')
+
+const ids = new Set()
+for (const e of plugins) {
+  if (typeof e?.id !== 'string' || !/^[a-z0-9][a-z0-9-]*$/.test(e.id)) { errors.push(`条目 id 非法：${JSON.stringify(e?.id)}`); continue }
+  if (RESERVED.has(e.id)) errors.push(`id ${e.id} 是保留字，会与网站手写页面冲突`)
+  if (ids.has(e.id)) errors.push(`id 重复：${e.id}`)
+  ids.add(e.id)
+  for (const lang of ['zh', 'en']) {
+    const f = join(CACHE, 'content', e.id, `${lang}.md`)
+    if (!existsSync(f) || !readFileSync(f, 'utf8').trim()) errors.push(`条目 ${e.id} 缺少 content/${e.id}/${lang}.md`)
+  }
+}
+const contentRoot = join(CACHE, 'content')
+if (existsSync(contentRoot)) {
+  for (const name of readdirSync(contentRoot)) {
+    if (statSync(join(contentRoot, name)).isDirectory() && !ids.has(name)) errors.push(`content/${name}/ 无对应 registry 条目`)
+  }
+}
+if (errors.length) fail(`数据校验未过（${errors.length} 处）：\n  ${errors.join('\n  ')}`)
+
+// ── 3. 拷贝 ────────────────────────────────────────────────────────────────
+mkdirSync(DATA_DIR, { recursive: true })
+for (const f of ['registry.json', 'categories.json']) {
+  if (existsSync(join(CACHE, f))) cpSync(join(CACHE, f), join(DATA_DIR, f))
+}
+
+// 清理上一轮生成、本轮已下架的插件目录（按 manifest，不误伤手写内容）
+const prevGenerated = existsSync(MANIFEST) ? JSON.parse(readFileSync(MANIFEST, 'utf8')) : []
+for (const id of prevGenerated) {
+  if (ids.has(id)) continue
+  for (const { base } of SIDES) rmSync(join(base, id), { recursive: true, force: true })
+  console.log(`  - 移除已下架插件目录：${id}`)
+}
+
+for (const { base } of SIDES) mkdirSync(base, { recursive: true })
+for (const id of ids) {
+  for (const { lang, base } of SIDES) {
+    const dir = join(base, id)
+    rmSync(dir, { recursive: true, force: true })
+    mkdirSync(dir, { recursive: true })
+    cpSync(join(CACHE, 'content', id, `${lang}.md`), join(dir, 'index.md'))
+    const assets = join(CACHE, 'content', id, 'assets')
+    if (existsSync(assets)) cpSync(assets, join(dir, 'assets'), { recursive: true })
+  }
+}
+writeFileSync(MANIFEST, JSON.stringify([...ids], null, 2) + '\n')
+
+const sha = git(['rev-parse', '--short', 'HEAD'], { cwd: CACHE, encoding: 'utf8' })
+console.log(`✓ marketplace-fetch：${plugins.length} 个插件 @ ${SRC.split('/').pop().replace('.git', '')}@${REF}${sha.status === 0 ? `(${sha.stdout.trim()})` : ''}`)

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -90,7 +90,8 @@ const navEn = [
 
 // ── 侧边栏：按路径分册 ─────────────────────────────────────────────────────
 // '/' = 用户手册（指南 / dsh 手册 / 功能 / 参考）；'/plugins/' = 开发手册；
-// '/marketplace/' 单页不给侧边栏。文件不动、链接不变，仅导航重组。
+// '/marketplace/' = 插件市场（列表 + 收录指南；插件详情页由 marketplace 仓
+// 数据生成，不进 sidebar——清单功能与卡片网格重复，数据缺失也不该炸配置）。
 const sidebarZh = {
   '/': [
     {
@@ -170,7 +171,15 @@ const sidebarZh = {
       ],
     },
   ],
-  '/marketplace/': [],
+  '/marketplace/': [
+    {
+      text: '市场',
+      items: [
+        { text: '插件列表', link: '/marketplace/' },
+        { text: '收录指南', link: '/marketplace/submit' },
+      ],
+    },
+  ],
 }
 
 const sidebarEn = {
@@ -252,7 +261,15 @@ const sidebarEn = {
       ],
     },
   ],
-  '/en/marketplace/': [],
+  '/en/marketplace/': [
+    {
+      text: 'Marketplace',
+      items: [
+        { text: 'All plugins', link: '/en/marketplace/' },
+        { text: 'Submission guide', link: '/en/marketplace/submit' },
+      ],
+    },
+  ],
 }
 
 const config = defineConfig({

--- a/website/.vitepress/data/marketplace.data.ts
+++ b/website/.vitepress/data/marketplace.data.ts
@@ -1,0 +1,64 @@
+// 市场数据加载器（构建期 Node 执行，结果序列化为 JSON 供组件消费）。
+// 数据来源是 script/marketplace-fetch.mjs 拷入的 marketplace 仓生成物；
+// 本地未拉取数据时返回 available:false 降级（页面渲染提示，不炸构建）。
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+export interface MarketplaceInstall {
+  kind: 'github' | 'git' | 'npm' | 'tarball'
+  spec: string
+}
+
+export interface MarketplaceEntry {
+  id: string
+  package: string
+  version: string
+  title: { zh: string; en: string }
+  tagline: { zh: string; en: string }
+  author: string
+  repo: string
+  install: MarketplaceInstall[]
+  capabilities: string[]
+  categories: string[]
+  license: string
+  verified: boolean
+  npm: string | null
+  image: string | null
+  added: string
+}
+
+export interface MarketplaceCategory {
+  id: string
+  zh: string
+  en: string
+}
+
+export interface MarketplaceData {
+  available: boolean
+  plugins: MarketplaceEntry[]
+  categories: MarketplaceCategory[]
+}
+
+declare const data: MarketplaceData
+export { data }
+
+const DATA_DIR = fileURLToPath(new URL('../marketplace-data/', import.meta.url))
+
+export default {
+  watch: ['../marketplace-data/*.json'],
+  load(): MarketplaceData {
+    const registryFile = `${DATA_DIR}registry.json`
+    const categoriesFile = `${DATA_DIR}categories.json`
+    if (!existsSync(registryFile) || !existsSync(categoriesFile)) {
+      return { available: false, plugins: [], categories: [] }
+    }
+    try {
+      const registry = JSON.parse(readFileSync(registryFile, 'utf8'))
+      const categories: MarketplaceCategory[] = JSON.parse(readFileSync(categoriesFile, 'utf8'))
+      const plugins: MarketplaceEntry[] = Array.isArray(registry?.plugins) ? registry.plugins : []
+      return { available: true, plugins, categories }
+    } catch {
+      return { available: false, plugins: [], categories: [] }
+    }
+  },
+}

--- a/website/.vitepress/theme/components/InstallCommand.vue
+++ b/website/.vitepress/theme/components/InstallCommand.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+// 与全站 fenced bash 代码块完全同构：复用主题的 language-bash DOM 结构与
+// 类名，块外观、暗色切换、右上角 bash 标签与复制按钮全部由主题样式接管；
+// 复制交互走主题的全局 click 代理（vitepress copyCode.js 匹配
+// div[class*="language-"] > button.copy），本组件自身零 JS、SSR 安全。
+// wrap=true 用于列表页卡片：窄列允许折行、去外边距、复制按钮常显（触屏可发现）。
+import { computed } from 'vue'
+
+const props = defineProps<{ command: string; wrap?: boolean }>()
+
+// shiki(github-light/dark) 对 bash 的着色实际只有两档：命令名（紫）与其余实参（蓝）
+const tokens = computed(() => {
+  const m = props.command.match(/^(\S+)([\s\S]*)$/)!
+  return [
+    { text: m[1], style: { '--shiki-light': '#6F42C1', '--shiki-dark': '#B392F0' } },
+    { text: m[2], style: { '--shiki-light': '#032F62', '--shiki-dark': '#9ECBFF' } },
+  ]
+})
+</script>
+
+<template>
+  <div class="language-bash vp-adaptive-theme mp-install" :class="{ wrap: props.wrap }">
+    <button title="Copy Code" class="copy"></button>
+    <span class="lang">bash</span>
+    <pre class="shiki shiki-themes github-light github-dark vp-code" tabindex="0"><code><span class="line"><span
+      v-for="(t, i) in tokens"
+      :key="i"
+      :style="t.style"
+    >{{ t.text }}</span></span></code></pre>
+  </div>
+</template>
+
+<style scoped>
+/* 卡片场景的微调：其余全部继承主题的 fenced 块样式 */
+.mp-install.wrap {
+  margin: 0;
+}
+.mp-install.wrap pre,
+.mp-install.wrap code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.mp-install.wrap .copy {
+  opacity: 1;
+}
+</style>

--- a/website/.vitepress/theme/components/MarketplaceCard.vue
+++ b/website/.vitepress/theme/components/MarketplaceCard.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+// 市场插件卡片：整卡可点进详情页（stretch-link 覆盖层实现），
+// 安装命令条 zIndex 更高，复制按钮的点击不会触发跳转。
+import { computed } from 'vue'
+import { withBase } from 'vitepress'
+import type { MarketplaceEntry, MarketplaceCategory } from '../../data/marketplace.data'
+import InstallCommand from './InstallCommand.vue'
+
+const props = defineProps<{
+  plugin: MarketplaceEntry
+  categories: MarketplaceCategory[]
+  lang: 'zh' | 'en'
+}>()
+
+const pick = (obj: { zh?: string; en?: string }) =>
+  obj?.[props.lang] || obj?.zh || obj?.en || ''
+
+const title = computed(() => pick(props.plugin.title))
+const tagline = computed(() => pick(props.plugin.tagline))
+const href = computed(() =>
+  withBase(`${props.lang === 'en' ? '/en' : ''}/marketplace/${props.plugin.id}/`))
+const categoryLabels = computed(() =>
+  props.categories
+    .filter((c) => props.plugin.categories.includes(c.id))
+    .map((c) => (props.lang === 'en' ? c.en : c.zh)))
+const installCommand = computed(() =>
+  `blue plugin add ${props.plugin.install[0]?.spec ?? ''}`)
+</script>
+
+<template>
+  <article class="card">
+    <div class="head">
+      <a class="title-link" :href="href">
+        <span class="title">{{ title }}</span>
+        <span v-if="plugin.verified" class="badge" :title="lang === 'en' ? 'Verified by maintainers' : '维护者已验证'">
+          <svg aria-hidden viewBox="0 0 24 24" width="11" height="11" fill="currentColor">
+            <path d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z" />
+          </svg>
+          {{ lang === 'en' ? 'Verified' : '已验证' }}
+        </span>
+      </a>
+      <span class="version">v{{ plugin.version }}</span>
+    </div>
+
+    <p class="tagline">{{ tagline }}</p>
+
+    <div class="meta">
+      <span class="author">{{ plugin.author }}</span>
+      <span v-for="c in categoryLabels" :key="c" class="cat">{{ c }}</span>
+      <span class="spacer" />
+      <span v-for="cap in plugin.capabilities" :key="cap" class="cap">{{ cap }}</span>
+    </div>
+
+    <div class="install">
+      <InstallCommand :command="installCommand" wrap />
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 12px;
+  background: var(--vp-c-bg-soft);
+  transition: border-color 0.2s;
+}
+.card:hover {
+  border-color: var(--vp-c-brand);
+}
+.head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.title-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  /* stretch link：覆盖层铺满整卡，整卡可点 */
+}
+.title-link::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+}
+.title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  color: var(--vp-c-green-1);
+  background: var(--vp-c-green-soft);
+  border: 1px solid var(--vp-c-green-2);
+}
+.version {
+  flex-shrink: 0;
+  font-size: 12px;
+  color: var(--vp-c-text-3);
+  font-family: var(--vp-font-family-mono);
+}
+.tagline {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--vp-c-text-2);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 2.9em;
+}
+.meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--vp-c-text-3);
+}
+.author {
+  color: var(--vp-c-text-2);
+}
+.cat {
+  padding: 1px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--vp-c-border);
+  background: var(--vp-c-bg);
+}
+.cap {
+  font-family: var(--vp-font-family-mono);
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+}
+.spacer {
+  flex: 1;
+}
+/* 安装命令条压在 stretch-link 之上，复制可点、不触发跳转 */
+.install {
+  position: relative;
+  z-index: 1;
+  margin-top: auto;
+}
+</style>

--- a/website/.vitepress/theme/components/MarketplaceGrid.vue
+++ b/website/.vitepress/theme/components/MarketplaceGrid.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+// 市场列表：搜索 + 分类筛选 + 卡片网格。数据来自 data loader（构建期生成），
+// 双语字段按当前 locale 取值，缺失回退另一语言。
+import { computed, ref } from 'vue'
+import { useData } from 'vitepress'
+import { data } from '../../data/marketplace.data'
+import MarketplaceCard from './MarketplaceCard.vue'
+
+const { localeIndex } = useData()
+const lang = computed<'zh' | 'en'>(() => (localeIndex.value === 'en' ? 'en' : 'zh'))
+const t = computed(() =>
+  lang.value === 'en'
+    ? {
+        count: (n: number) => `${n} plugin${n === 1 ? '' : 's'}`,
+        verified: (n: number) => `${n} verified`,
+        search: 'Search by name, author, or package…',
+        all: 'All',
+        missing: 'Marketplace data not synced',
+        missingHint: 'Run pnpm marketplace:fetch locally and reload (production builds fetch automatically).',
+        empty: 'Nothing listed yet',
+        emptyHint: 'Yours could be the first — see the submission guide.',
+        emptyCta: 'Submit a plugin',
+      }
+    : {
+        count: (n: number) => `共 ${n} 个插件`,
+        verified: (n: number) => `已验证 ${n}`,
+        search: '按名称、作者或包名搜索…',
+        all: '全部',
+        missing: '市场数据未同步',
+        missingHint: '本地运行 pnpm marketplace:fetch 后刷新（生产构建会自动拉取）。',
+        empty: '暂无收录',
+        emptyHint: '第一个被收录的可能就是你。',
+        emptyCta: '提交插件',
+      })
+
+const query = ref('')
+const activeCategory = ref<string | null>(null)
+
+const filtered = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  return data.plugins.filter((p) => {
+    if (activeCategory.value && !p.categories.includes(activeCategory.value)) return false
+    if (!q) return true
+    const hay = [
+      p.id, p.package, p.author,
+      p.title.zh, p.title.en, p.tagline.zh, p.tagline.en,
+      ...p.categories,
+    ].join('\n').toLowerCase()
+    return hay.includes(q)
+  })
+})
+const verifiedCount = computed(() => data.plugins.filter((p) => p.verified).length)
+const catLabel = (id: string) => {
+  const c = data.categories.find((c) => c.id === id)
+  return c ? (lang.value === 'en' ? c.en : c.zh) : id
+}
+</script>
+
+<template>
+  <!-- 数据未同步：本地未拉取时的降级提示（CI 为严格模式，生产不会出现） -->
+  <div v-if="!data.available" class="notice">
+    <p class="notice-title">{{ t.missing }}</p>
+    <p class="notice-hint">{{ t.missingHint }}</p>
+  </div>
+
+  <template v-else>
+    <div class="toolbar">
+      <span class="stats">{{ t.count(data.plugins.length) }} · {{ t.verified(verifiedCount) }}</span>
+      <input
+        v-model="query"
+        type="search"
+        class="search"
+        :placeholder="t.search"
+        :aria-label="t.search"
+      >
+      <div class="chips" role="group" :aria-label="lang === 'en' ? 'Categories' : '分类'">
+        <button
+          type="button"
+          class="chip"
+          :class="{ active: activeCategory === null }"
+          @click="activeCategory = null"
+        >{{ t.all }}</button>
+        <button
+          v-for="c in data.categories"
+          :key="c.id"
+          type="button"
+          class="chip"
+          :class="{ active: activeCategory === c.id }"
+          @click="activeCategory = activeCategory === c.id ? null : c.id"
+        >{{ catLabel(c.id) }}</button>
+      </div>
+    </div>
+
+    <div v-if="filtered.length" class="grid">
+      <MarketplaceCard
+        v-for="p in filtered"
+        :key="p.id"
+        :plugin="p"
+        :categories="data.categories"
+        :lang="lang"
+      />
+    </div>
+
+    <div v-else class="notice">
+      <p class="notice-title">{{ t.empty }}</p>
+      <p class="notice-hint">
+        {{ t.emptyHint }}
+        <a :href="lang === 'en' ? '/en/marketplace/submit' : '/marketplace/submit'">{{ t.emptyCta }} →</a>
+      </p>
+    </div>
+  </template>
+</template>
+
+<style scoped>
+.toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 20px 0 16px;
+}
+.stats {
+  font-size: 13px;
+  color: var(--vp-c-text-3);
+  white-space: nowrap;
+}
+.search {
+  flex: 1;
+  min-width: 200px;
+  max-width: 340px;
+  padding: 7px 12px;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 8px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  font-size: 13px;
+}
+.search:focus {
+  border-color: var(--vp-c-brand);
+  outline: none;
+}
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.chip {
+  padding: 4px 12px;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 999px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-2);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.chip:hover {
+  color: var(--vp-c-text-1);
+  border-color: var(--vp-c-text-3);
+}
+.chip.active {
+  color: var(--vp-c-brand);
+  border-color: var(--vp-c-brand);
+  background: var(--vp-c-brand-dim, var(--vp-c-bg-soft));
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 14px;
+}
+.notice {
+  margin: 24px 0;
+  padding: 18px 20px;
+  border: 1px dashed var(--vp-c-border);
+  border-radius: 12px;
+  background: var(--vp-c-bg-soft);
+}
+.notice-title {
+  margin: 0 0 6px;
+  font-weight: 600;
+  color: var(--vp-c-text-1);
+}
+.notice-hint {
+  margin: 0;
+  font-size: 13.5px;
+  color: var(--vp-c-text-2);
+}
+</style>

--- a/website/.vitepress/theme/components/PluginMeta.vue
+++ b/website/.vitepress/theme/components/PluginMeta.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+// 详情页元信息：从注册表按 id 渲染（版本/license/仓库等不手抄，改 registry 即全站同步）。
+// id 打错时渲染灰字占位，避免外部内容打错字导致静默空白。
+import { computed } from 'vue'
+import { useData } from 'vitepress'
+import { data } from '../../data/marketplace.data'
+
+const props = defineProps<{ id: string }>()
+
+const { localeIndex } = useData()
+const lang = computed<'zh' | 'en'>(() => (localeIndex.value === 'en' ? 'en' : 'zh'))
+const entry = computed(() => data.plugins.find((p) => p.id === props.id))
+
+const label = computed<Record<string, string>>(() =>
+  lang.value === 'en'
+    ? {
+        heading: 'Details',
+        version: 'Version',
+        license: 'License',
+        repo: 'Repository',
+        capabilities: 'Capabilities',
+        categories: 'Categories',
+        npm: 'npm',
+        added: 'Listed',
+        notPublished: 'Not published to npm',
+        missing: `No registry entry found for id "${props.id}"`,
+      }
+    : {
+        heading: '信息',
+        version: '版本',
+        license: '许可证',
+        repo: '仓库',
+        capabilities: '能力',
+        categories: '分类',
+        npm: 'npm',
+        added: '收录日期',
+        notPublished: '未发布 npm 包',
+        missing: `registry 中未找到 id 为 "${props.id}" 的条目`,
+      })
+
+const categoryLabels = computed(() =>
+  data.categories
+    .filter((c) => entry.value?.categories.includes(c.id))
+    .map((c) => (lang.value === 'en' ? c.en : c.zh)))
+</script>
+
+<template>
+  <div v-if="entry" class="plugin-meta">
+    <p class="heading">{{ label.heading }}</p>
+    <dl>
+      <div class="row">
+        <dt>{{ label.version }}</dt>
+        <dd><code>v{{ entry.version }}</code></dd>
+      </div>
+      <div class="row">
+        <dt>{{ label.license }}</dt>
+        <dd>{{ entry.license }}</dd>
+      </div>
+      <div class="row">
+        <dt>{{ label.repo }}</dt>
+        <dd>
+          <a :href="entry.repo" target="_blank" rel="noopener">{{ entry.repo.replace('https://github.com/', '') }}</a>
+        </dd>
+      </div>
+      <div class="row">
+        <dt>{{ label.capabilities }}</dt>
+        <dd><code v-for="c in entry.capabilities" :key="c" class="cap">{{ c }}</code></dd>
+      </div>
+      <div class="row">
+        <dt>{{ label.categories }}</dt>
+        <dd>{{ categoryLabels.join(' / ') }}</dd>
+      </div>
+      <div class="row">
+        <dt>{{ label.npm }}</dt>
+        <dd>{{ entry.npm ? entry.npm : label.notPublished }}</dd>
+      </div>
+      <div class="row">
+        <dt>{{ label.added }}</dt>
+        <dd>{{ entry.added }}</dd>
+      </div>
+    </dl>
+  </div>
+  <p v-else class="missing">{{ label.missing }}</p>
+</template>
+
+<style scoped>
+.plugin-meta {
+  margin: 28px 0 0;
+  padding-top: 18px;
+  border-top: 1px solid var(--vp-c-divider);
+}
+.heading {
+  margin: 0 0 10px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vp-c-text-3);
+}
+dl {
+  margin: 0;
+  display: grid;
+  gap: 6px;
+}
+.row {
+  display: flex;
+  gap: 12px;
+  font-size: 13.5px;
+  line-height: 1.6;
+}
+dt {
+  flex-shrink: 0;
+  width: 7.5em;
+  color: var(--vp-c-text-3);
+}
+dd {
+  margin: 0;
+  color: var(--vp-c-text-2);
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+dd a {
+  color: var(--vp-c-brand);
+  text-decoration: none;
+}
+dd a:hover {
+  text-decoration: underline;
+}
+code.cap {
+  margin-right: 6px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  font-size: 12px;
+}
+.missing {
+  margin: 24px 0 0;
+  font-size: 13px;
+  color: var(--vp-c-text-3);
+}
+</style>

--- a/website/.vitepress/theme/index.ts
+++ b/website/.vitepress/theme/index.ts
@@ -1,5 +1,8 @@
 import DefaultTheme from 'vitepress/theme'
 import type { Theme } from 'vitepress'
+import MarketplaceGrid from './components/MarketplaceGrid.vue'
+import InstallCommand from './components/InstallCommand.vue'
+import PluginMeta from './components/PluginMeta.vue'
 
 // 粘性语言切换（ADR D32）：head 内联脚本负责整页加载时的自动分流且不写偏好；
 // 这里在 SPA 导航（含手动切换语言）时把落点 locale 盖章为偏好，此后自动分流
@@ -8,7 +11,13 @@ const PREF_KEY = 'dsh-blue-docs-lang'
 
 export default {
   extends: DefaultTheme,
-  enhanceApp({ router }) {
+  enhanceApp({ app, router }) {
+    // 市场全局组件。必须注册在下方 window 守卫之前——SSR 构建不执行守卫后的
+    // 代码，放守卫后组件不会注册；InstallCommand/PluginMeta 还被 marketplace
+    // 仓拷入的外部 md 使用，只能走全局注册。
+    app.component('MarketplaceGrid', MarketplaceGrid)
+    app.component('InstallCommand', InstallCommand)
+    app.component('PluginMeta', PluginMeta)
     if (typeof window === 'undefined') return
     // 注意必须先剥 Vite base（Pages 下为 /blue/）再判 locale，
     // 否则所有导航都会被误判为根路径语言（中文）。

--- a/website/en/marketplace/index.md
+++ b/website/en/marketplace/index.md
@@ -1,26 +1,13 @@
 # Plugin marketplace
 
-::: info Under construction
-The Blue ecosystem plugin marketplace will be implemented as a separate repository (listing, indexing, and card display); it is currently in the planning stage. This page is a placeholder and will go live together with the marketplace.
+The place to discover and install Blue ecosystem plugins: third-party plugins built on the stable [seams](/en/plugins/seams) and public APIs, listed here and installed into your Blue with one line.
+
+::: info Before installing a plugin
+Every plugin in the marketplace runs on top of Blue — [install Blue](/en/guide/) first. The install command is always `blue plugin add <spec>` (equivalent to `dsh plugin --profile blue add <spec>`), where `<spec>` is the source shown on the card or detail page; see the [dsh plugin docs](/en/dsh/plugins) for the mechanism.
 :::
 
-## What this will be
+<MarketplaceGrid />
 
-A marketplace for **Blue downstream developers'** ecosystem plugins: status, dock, command, and notification plugins built through the stable [seams and public API](/en/plugins/seams) can be published to npm, listed here, and installed by other users in one line.
+## List your plugin
 
-Each card will look roughly like this:
-
-```
-┌─────────────────────────────────────┐
-│ my-plugin-clock              v0.1.0 │
-│ status-bar clock + /now command     │
-│ ★ 12 · status bar / commands        │
-│ dsh plugin add my-scope/my-pkg      │
-└─────────────────────────────────────┘
-```
-
-## Until it opens
-
-- To develop a plugin: start with the [quickstart](/en/plugins/quickstart); the seam catalog is the [Seam reference](/en/plugins/seams);
-- To inspect the current composition: see the Blue bundle's 28 owned rows in [Built-in plugins](/en/plugins/builtins);
-- Watch the [GitHub repository](https://github.com/dsh-blue/blue) for the marketplace announcement.
+Built something others would enjoy? Submit it to the [dsh-blue/marketplace](https://github.com/dsh-blue/marketplace) repository — **any plugin installable from GitHub qualifies; npm is not a requirement** (an npm source can be added after publishing). The full process, field reference, and writing guidelines are in the [submission guide](/en/marketplace/submit).

--- a/website/en/marketplace/submit.md
+++ b/website/en/marketplace/submit.md
@@ -1,0 +1,93 @@
+# Submission guide
+
+Listing your plugin in the [plugin marketplace](/en/marketplace/) is a single pull request to the [dsh-blue/marketplace](https://github.com/dsh-blue/marketplace) repository. This page covers the listing criteria, the registry fields, how to write the detail pages, and the review process.
+
+## Listing criteria
+
+- **Installable**: the plugin installs from a public source via `blue plugin add <spec>` (a GitHub source is enough; npm is not a requirement — an npm source can be added after publishing). The package name must contain `blue`, `frontend`, or `adapter`, matching the main repository's validation rule;
+- **Public capabilities only**: the plugin uses only the four capabilities open in phase one — `commands` / `status` / `dock` / `notifications` — and the declaration matches reality (see the capability contracts in [Core concepts](/en/plugins/concepts));
+- **Bilingual basics**: `title` and `tagline` must be provided in both Chinese and English; the tagline is one action sentence describing what the plugin does (Chinese ≤60 characters, English ≤100 characters, English ends with a period, no emoji);
+- **Accurate metadata**: `version` and `license` match the source repository.
+
+To learn how plugins are written and verified, start with the [quickstart](/en/plugins/quickstart); run your plugin through [debugging and validation](/en/plugins/testing) before submitting.
+
+## Registry fields
+
+A listing is one entry appended to the **end** of the `plugins` array in `registry.json`:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `id` | ✓ | Unique id — also the marketplace URL slug and the `content/<id>/` directory name; `^[a-z0-9][a-z0-9-]*$`; `submit` is reserved |
+| `package` | ✓ | Target package name (matching `name` in the source repository's `package.json`) |
+| `version` | ✓ | Display version |
+| `title` | ✓ | Display name in both languages `{ "zh": ..., "en": ... }` |
+| `tagline` | ✓ | One-line description in both languages (style rules above) |
+| `author` | ✓ | Author display name |
+| `repo` | ✓ | `https://github.com/<owner>/<repo>` source repository |
+| `install` | ✓ | Install sources (at least one; **order is the preference order**, the card shows the first): `{ "kind": "github" \| "git" \| "npm" \| "tarball", "spec": ... }` — `spec` plugs directly into `blue plugin add <spec>` |
+| `capabilities` | ✓ | Blue capabilities used |
+| `categories` | ✓ | Categories from the vocabulary in `categories.json` |
+| `license` | ✓ | SPDX identifier |
+| `verified` | ✓ | Always `false` when submitting; maintainers flip it during review |
+| `added` | ✓ | Listing date `YYYY-MM-DD` |
+| `npm` |  | Package name once published to npm, `null` before; must not be `null` when an `npm` install source is present |
+| `image` |  | Card cover / detail hero image, a relative path under `content/<id>/assets/`; `null` for now |
+
+The first listed entry, `blue-doudizhu`, is a good reference:
+
+```json
+{
+  "id": "blue-doudizhu",
+  "package": "@dsh-blue/blue-doudizhu",
+  "version": "0.1.0",
+  "title": { "zh": "斗地主", "en": "Doudizhu" },
+  "tagline": {
+    "zh": "在 Dock 面板里打斗地主：字符牌局、本地 Bot 对手与积分排行榜。",
+    "en": "Play Doudizhu in a dock pane: a character-drawn card table, local bots, and a score leaderboard."
+  },
+  "author": "dsh-blue",
+  "repo": "https://github.com/dsh-blue/blue-doudizhu",
+  "install": [
+    { "kind": "github", "spec": "github:dsh-blue/blue-doudizhu" },
+    { "kind": "git", "spec": "git+https://github.com/dsh-blue/blue-doudizhu.git" }
+  ],
+  "capabilities": ["commands", "dock"],
+  "categories": ["games"],
+  "license": "MIT",
+  "verified": true,
+  "npm": null,
+  "image": null,
+  "added": "2026-08-27"
+}
+```
+
+## Writing the detail pages
+
+Each plugin ships bilingual detail pages `content/<id>/zh.md` and `content/<id>/en.md`, rendered by the website at `/marketplace/<id>/` and `/en/marketplace/<id>/`. Conventions:
+
+- Start the file with frontmatter `title:` and include a level-one heading in the body;
+- Structure as needed: overview → prerequisites (installing Blue) → installation → commands/usage → capabilities → features → FAQ;
+- **Never hand-copy install commands or metadata**: render them from the registry with the global components — `<InstallCommand command="blue plugin add <spec>" />` for a copyable install command, and `<PluginMeta id="<id>" />` for version/license/repository metadata. That way version numbers live in exactly one place, `registry.json`;
+- Site-internal links use absolute paths with the language prefix (Chinese pages `/plugins/...`, English pages `/en/plugins/...`); end the page with a "back to the marketplace" link.
+
+See [`content/blue-doudizhu/`](https://github.com/dsh-blue/marketplace/tree/master/content/blue-doudizhu) in the marketplace repository for a full example.
+
+## Pull request process
+
+1. Fork [dsh-blue/marketplace](https://github.com/dsh-blue/marketplace) and create a branch;
+2. Append the entry to the end of `registry.json` and add `content/<id>/zh.md` and `en.md`;
+3. Open a PR titled `add: <id>`;
+4. **One plugin per PR**; you may only touch `registry.json` and your own `content/<id>/` directory (the same applies when updating your plugin later) — changes to other entries are rejected;
+5. Set `verified` to `false`; once CI and human review pass, the PR is merged and the site updates by the next day (daily rebuild).
+
+## Automated checks
+
+Every PR runs [validate-registry](https://github.com/dsh-blue/marketplace/blob/master/script/validate-registry.mjs); you can run `node script/validate-registry.mjs` locally before submitting. It checks: JSON parses; field whitelist (unknown keys fail, so typos are never silently dropped); `id` uniqueness, format, and reserved words; package-name rule; `repo` format; install-source validity (`npm` field non-null when an npm source is present); capabilities and categories within their vocabularies; tagline bilingual completeness, length, and style; bilingual detail files present with frontmatter `title` and a level-one heading; `content/` directories matching entries one-to-one; and **a PR by a non-maintainer that introduces `"verified": true` fails outright**.
+
+## Human review checklist
+
+Before merging, maintainers verify:
+
+- The plugin **actually installs** via the first `install` source (`blue plugin add <spec>`), and after a Blue restart the commands/panes appear;
+- `capabilities` match what the plugin really uses; `version` and `license` match the source repository;
+- The tagline is equivalent in both languages and leads with a verb; detail-page internal links carry the correct language prefix.

--- a/website/en/plugins/publishing.md
+++ b/website/en/plugins/publishing.md
@@ -39,4 +39,4 @@ A package without a `dsh.bundle` declaration installs as a plain dependency only
 
 ## Plugin marketplace
 
-One-command install and discovery (the [plugin marketplace](/en/marketplace/)) are on the roadmap. The distribution mechanism of the current phase is npm + a patch row — keep your package independently installable (this is what the fixture verifies), and your package needs no rework when the marketplace lands.
+The [plugin marketplace](/en/marketplace/) is live: after publishing, submit a listing to [dsh-blue/marketplace](https://github.com/dsh-blue/marketplace) and users can install your plugin from the marketplace in one line (any plugin installable from GitHub qualifies — npm is not a requirement). The listing process and field reference are in the [submission guide](/en/marketplace/submit). The distribution mechanism is still an npm/GitHub source plus a patch row — keep your package independently installable (this is what the fixture verifies), and listing requires no rework of the package.

--- a/website/marketplace/index.md
+++ b/website/marketplace/index.md
@@ -1,26 +1,13 @@
 # 插件市场
 
-::: info 建设中
-Blue 生态插件市场将以独立仓库实现（收录、索引与卡片展示），目前处于规划阶段。本页为占位，开放后同步上线。
+Blue 生态插件的发现与安装入口：基于稳定 [Seam](/plugins/seams) 与公开 API 开发的第三方插件在这里集中展示，一行命令装进你的 Blue。
+
+::: info 安装插件前
+市场中的插件都运行在 Blue 之上，请先[安装 Blue](/guide/)。安装命令统一为 `blue plugin add <spec>`（等价于 `dsh plugin --profile blue add <spec>`），`<spec>` 为卡片或详情页给出的安装源；机制细节参见 [dsh 插件文档](/dsh/plugins)。
 :::
 
-## 这里是什么
+<MarketplaceGrid />
 
-面向 **Blue 下游开发者**的生态插件市场：你通过 [Seam](/plugins/seams) 和稳定 public API 编写的 status、dock、command、notification 插件，发布到 npm 后收录于此，其他用户一行安装。
+## 收录你的插件
 
-每张卡片大致长这样：
-
-```
-┌─────────────────────────────────────┐
-│ my-plugin-clock              v0.1.0 │
-│ 状态栏时钟 + /now 命令                 │
-│ ★ 12 · 状态栏 / 命令                  │
-│ dsh plugin add my-scope/my-pkg      │
-└─────────────────────────────────────┘
-```
-
-## 上线之前
-
-- 想开发插件：从[快速开始](/plugins/quickstart)入手，缝的目录见 [Seam 参考](/plugins/seams)；
-- 想看当前组合：Blue bundle 的 28 条自有行见[内置插件](/plugins/builtins)；
-- 关注 [GitHub 仓库](https://github.com/dsh-blue/blue)获取市场开放公告。
+写好了插件想让更多人用上？往 [dsh-blue/marketplace](https://github.com/dsh-blue/marketplace) 仓库提交收录即可——**GitHub 可安装的插件就能收录，npm 不是门槛**（发布 npm 后补一条安装源即可）。完整流程、字段说明与写作规范见[收录指南](/marketplace/submit)。

--- a/website/marketplace/submit.md
+++ b/website/marketplace/submit.md
@@ -1,0 +1,93 @@
+# 收录指南
+
+把你的插件收录进[插件市场](/marketplace/)：往 [dsh-blue/marketplace](https://github.com/dsh-blue/marketplace) 仓库提交一个 PR 即可。本页说明收录标准、注册表字段、详情页写法与审查流程。
+
+## 收录标准
+
+- **可安装**：插件能通过 `blue plugin add <spec>` 从公开源安装（GitHub 源即可；npm 不是门槛，发布后补一条安装源即可）。包名必须包含 `blue`、`frontend` 或 `adapter` 之一，与主仓校验规则一致；
+- **基于公开能力**：只使用 phase one 开放的四种能力 `commands` / `status` / `dock` / `notifications`，且声明与实际相符（能力契约见[核心概念](/plugins/concepts)）；
+- **双语基本信息**：`title` 与 `tagline` 必须中英齐全；tagline 用一句动作句概括插件做什么（中文 ≤60 字符、英文 ≤100 字符、英文以句号结尾、不用 emoji）；
+- **信息如实**：`version`、`license` 与源仓库一致。
+
+插件怎么写、怎么验证，从[快速开始](/plugins/quickstart)入手；发布前建议过一遍[调试与验证](/plugins/testing)。
+
+## 注册表字段
+
+收录即往 `registry.json` 的 `plugins` 数组**末尾追加**一条：
+
+| 字段 | 必填 | 说明 |
+| --- | --- | --- |
+| `id` | ✓ | 唯一标识，即市场 URL 路径与 `content/<id>/` 目录名；`^[a-z0-9][a-z0-9-]*$`，`submit` 为保留字 |
+| `package` | ✓ | 目标包名（与源仓库 `package.json` 的 `name` 一致） |
+| `version` | ✓ | 展示用版本号 |
+| `title` | ✓ | 双语展示名 `{ "zh": ..., "en": ... }` |
+| `tagline` | ✓ | 双语一句话描述（风格要求见上） |
+| `author` | ✓ | 作者展示名 |
+| `repo` | ✓ | `https://github.com/<owner>/<repo>` 源码仓库 |
+| `install` | ✓ | 安装源数组（至少一项，**顺序即偏好序**，卡片展示第一项）：`{ "kind": "github" \| "git" \| "npm" \| "tarball", "spec": ... }`，`spec` 可直接拼进 `blue plugin add <spec>` |
+| `capabilities` | ✓ | 使用的 Blue 能力 |
+| `categories` | ✓ | 分类，取值见仓库 `categories.json` 词表 |
+| `license` | ✓ | SPDX 标识 |
+| `verified` | ✓ | 提交时一律 `false`，由维护者在 review 中翻转 |
+| `added` | ✓ | 收录日期 `YYYY-MM-DD` |
+| `npm` |  | 发布到 npm 后填包名，未发布填 `null`；含 `npm` 安装源时不可为 `null` |
+| `image` |  | 卡片封面/详情头图，`content/<id>/assets/` 下的相对路径，暂无填 `null` |
+
+首个收录条目 `blue-doudizhu` 可作参考：
+
+```json
+{
+  "id": "blue-doudizhu",
+  "package": "@dsh-blue/blue-doudizhu",
+  "version": "0.1.0",
+  "title": { "zh": "斗地主", "en": "Doudizhu" },
+  "tagline": {
+    "zh": "在 Dock 面板里打斗地主：字符牌局、本地 Bot 对手与积分排行榜。",
+    "en": "Play Doudizhu in a dock pane: a character-drawn card table, local bots, and a score leaderboard."
+  },
+  "author": "dsh-blue",
+  "repo": "https://github.com/dsh-blue/blue-doudizhu",
+  "install": [
+    { "kind": "github", "spec": "github:dsh-blue/blue-doudizhu" },
+    { "kind": "git", "spec": "git+https://github.com/dsh-blue/blue-doudizhu.git" }
+  ],
+  "capabilities": ["commands", "dock"],
+  "categories": ["games"],
+  "license": "MIT",
+  "verified": true,
+  "npm": null,
+  "image": null,
+  "added": "2026-08-27"
+}
+```
+
+## 详情页写法
+
+每个插件需要双语详情页 `content/<id>/zh.md` 与 `content/<id>/en.md`，网站会渲染为 `/marketplace/<id>/` 与 `/en/marketplace/<id>/`。写作约定：
+
+- 文件以 frontmatter `title:` 开头，正文含一个一级标题；
+- 按需分节：概述 → 前置条件（装 Blue）→ 安装 → 命令/用法 → 能力 → 特性 → 常见问题；
+- **安装命令与元信息不要手抄**：用全局组件从注册表渲染——`<InstallCommand command="blue plugin add <spec>" />` 渲染可复制的安装命令，`<PluginMeta id="<id>" />` 渲染版本/license/仓库等元信息；这样版本号等信息只需维护 `registry.json` 一处；
+- 站内链接写带语言前缀的绝对路径（中文页 `/plugins/...`、英文页 `/en/plugins/...`）；页面末尾放"返回插件市场"链接。
+
+范例见 marketplace 仓库 [`content/blue-doudizhu/`](https://github.com/dsh-blue/marketplace/tree/master/content/blue-doudizhu)。
+
+## PR 流程
+
+1. Fork [dsh-blue/marketplace](https://github.com/dsh-blue/marketplace)，新建分支；
+2. `registry.json` 末尾追加条目 + 新增 `content/<id>/zh.md`、`en.md`；
+3. 提交 PR，标题 `add: <id>`；
+4. **一个插件一个 PR**；只允许改动 `registry.json` 与自己的 `content/<id>/` 目录（更新自己的插件时同样只动自己的条目和目录），改动他人条目会被拒绝；
+5. `verified` 填 `false`；CI 校验与人工 review 通过后合并，网站最迟次日更新（每日定时重建）。
+
+## CI 自动校验
+
+PR 会自动运行 [validate-registry](https://github.com/dsh-blue/marketplace/blob/master/script/validate-registry.mjs)，提交前可在本地运行 `node script/validate-registry.mjs` 自查。校验项：JSON 可解析；字段白名单（未知键报错，防拼写错误被静默忽略）；`id` 唯一、格式与保留字；包名规则；`repo` 格式；安装源合法性（含 npm 源时 `npm` 字段非空）；能力与分类在词表内；tagline 双语齐全、长度与风格；双语详情文件存在且有 frontmatter `title` 与一级标题；`content/` 目录与条目一一对应；**非维护者在 PR 中引入 `"verified": true` 直接失败**。
+
+## 人工 review 清单
+
+维护者合并前会核对：
+
+- 按注册表 `install` 的第一项**实际安装**一次（`blue plugin add <spec>`），重启 Blue，确认命令/面板出现；
+- `capabilities` 与插件实际使用相符；`version`、`license` 与源仓库一致；
+- tagline 双语等值、动作句开头；详情页站内链接语言前缀正确。

--- a/website/plugins/publishing.md
+++ b/website/plugins/publishing.md
@@ -39,4 +39,4 @@ dsh plugin --profile blue add my-scope/blue-clock
 
 ## 插件市场
 
-一键安装与发现（[插件市场](/marketplace/)）在路线图上。当前阶段的分发方式就是 npm + patch 行——保持包的独立可安装性（fixture 验证的意义就在这里），市场落地时你的包无需改造。
+[插件市场](/marketplace/)已上线：发布后往 [dsh-blue/marketplace](https://github.com/dsh-blue/marketplace) 提交收录，用户即可在市场一行安装（GitHub 可安装的插件就能收录，npm 不是门槛）。收录流程与字段说明见[收录指南](/marketplace/submit)。分发机制依旧是 npm/GitHub 源 + patch 行——保持包的独立可安装性（fixture 验证的意义就在这里），收录不需要对包做任何改造。


### PR DESCRIPTION
## What

The `/marketplace/` placeholder becomes a live, registry-backed plugin directory. First listed plugin: **blue-doudizhu** (斗地主, `blue plugin add github:dsh-blue/blue-doudizhu`).

Data lives in a separate repo — [dsh-blue/marketplace](https://github.com/dsh-blue/marketplace) — as the single source of truth (registry + bilingual detail pages + validation CI). The website consumes it at build time; everything generated is untracked, so the release version-lockstep (`release-version.mjs` walks `git ls-files`) is unaffected.

## Website changes

- **First custom Vue components** (site had zero until now):
  - `MarketplaceGrid` — search + category chips + card grid, locale-aware fields, degraded mode when data is missing
  - `MarketplaceCard` — green verified badge, capability tags, install command
  - `InstallCommand` — renders a DOM **isomorphic to VitePress fenced bash blocks** (same chrome, `bash` label, copy via the theme's global click delegate; on cards it wraps and keeps the button visible)
  - `PluginMeta` — version/license/repo/capabilities rendered from the registry so detail pages never hand-copy metadata
- `script/marketplace-fetch.mjs` — zero-dep fetcher (clone → cross-validate → copy into `website/`), stale-entry cleanup by manifest, `--allow-missing` for dev, strict in CI
- `marketplace/index.md` rewritten as the listing page; **new bilingual `/marketplace/submit` submission guide** (criteria, field table, PR rules, CI checks, review checklist) wired into the sidebar
- `publishing.md` (zh/en): marketplace section updated from "on the roadmap" to live
- `website-pages.yml`: strict data fetch before build in both jobs, `script/marketplace-fetch.mjs` added to trigger paths, daily `schedule` so marketplace merges reach the site without a blue-repo push

## The marketplace repo

Live at https://github.com/dsh-blue/marketplace — `registry.json` (field whitelist, strict JSON), `categories.json` vocabulary, `content/<id>/{zh,en}.md`, and `validate-registry.mjs` (Obsidian-style gate: append-at-end, one plugin per PR, `verified` flips blocked for non-maintainers, bilingual content required).

## Verified locally

- Full build with data passes the dead-link gate; degraded build (no data) renders the not-synced notice and still passes
- Fetch script exit codes (strict/degraded), stale-plugin dir cleanup, id↔directory cross-validation
- Registry validator: 4 destructive cases + verified-flip protection (non-maintainer blocked, maintainer allowed)
- Browser QA via screenshots: zh/en × light/dark, card interactions (search, chips, copy), detail page, submit page, mobile width