### PR TITLE
feat(website): add Cloudflare Web Analytics

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -283,6 +283,14 @@ const config = defineConfig({
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: `${base}favicon.svg` }],
     ['script', {}, `(${langRedirect.toString()})(${JSON.stringify(base)})`],
+    [
+      'script',
+      {
+        type: 'module',
+        src: 'https://static.cloudflareinsights.com/beacon.min.js',
+        'data-cf-beacon': '{"token": "78f084a06ca54e528103657960a14b43"}',
+      },
+    ],
   ],
   locales: {
     root: {


### PR DESCRIPTION
## Summary
- add the Cloudflare Web Analytics beacon to VitePress global head
- cover all Chinese and English documentation pages

## Verification
- `pnpm run website:build`
- verified the generated dist contains the beacon in all 79 HTML pages