### PR TITLE
docs: define PR77 merge and plugin v1 delivery path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Every package entry is a Cordis plugin: it exports `name`, optionally `inject`, 
 
 ## Frontend Runtime 重构契约
 
-当前实现事实与包边界见 `docs/blue-architecture.md`、`docs/blue-seams.md` 和各包 `AGENTS.md`；插件 v1 的规范性目标见 `docs/blue-plugin-contract-v1.md`；PR #77 合并控制与后续 v1 发布执行分别见 `docs/blue-pr77-convergence-matrix.md` 和 `docs/blue-plugin-api-v1-roadmap.md`。以下纪律适用于当前主线及后续变更：
+当前实现事实与包边界见 `docs/blue-architecture.md`、`docs/blue-seams.md` 和各包 `AGENTS.md`；插件 v1 的规范性目标见 `docs/blue-plugin-contract-v1.md`；PR #79 发布边界、PR #77 合并 runbook 与后续独立 PR 队列见 `docs/blue-pr77-convergence-matrix.md`，阶段出口见 `docs/blue-plugin-api-v1-roadmap.md`。PR #79 是 docs-only 设计基线，不发布 runtime、npm package、Website v1 可用性或作者 skill。以下纪律适用于当前主线及后续变更：
 
 - **依赖方向**：Harness domain -> Blue frontend runtime -> renderer adapter；Domain 插件不得依赖 Blue，只有 core 接触 pi-tui/raw terminal。
 - **架构职责**：Domain、Interaction、Renderer、Composition 分开；官方包可暂时同仓，但契约、scope 和 Fiber ownership 不混合。它们不等于 manifest 的 `integrated | adapter | pure-ui` 三种 form。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,10 +76,10 @@ Every package entry is a Cordis plugin: it exports `name`, optionally `inject`, 
 
 ## Frontend Runtime 重构契约
 
-新架构开发主线为 p2/frontend-runtime，目标架构和阶段计划分别见 docs/blue-frontend-architecture.md 与 docs/blue-implementation-plan.md。以下契约适用于该分支及其后续合并：
+当前实现事实与包边界见 `docs/blue-architecture.md`、`docs/blue-seams.md` 和各包 `AGENTS.md`；插件 v1 的规范性目标见 `docs/blue-plugin-contract-v1.md`；PR #77 合并控制与后续 v1 发布执行分别见 `docs/blue-pr77-convergence-matrix.md` 和 `docs/blue-plugin-api-v1-roadmap.md`。以下纪律适用于当前主线及后续变更：
 
 - **依赖方向**：Harness domain -> Blue frontend runtime -> renderer adapter；Domain 插件不得依赖 Blue，只有 core 接触 pi-tui/raw terminal。
-- **插件分类**：Domain、Interaction、Renderer、Composition 分开；官方包可暂时同仓，但契约、scope 和 Fiber ownership 不混合。
+- **架构职责**：Domain、Interaction、Renderer、Composition 分开；官方包可暂时同仓，但契约、scope 和 Fiber ownership 不混合。它们不等于 manifest 的 `integrated | adapter | pure-ui` 三种 form。
 - **兼容 adapter**：必须是独立、窄化、按能力拆分的 Cordis 插件；只转换官方 API、集中 capability probing 和版本差异；不得暴露 Agent/Session、复制业务状态或 import package-internal；每个 adapter 必须记录删除条件。
 - **状态边界**：事件表示已发生事实，projection 表示当前状态，action 表示带结果的写请求；UI 不直接折叠 Harness session events，也不保存第二套 Agent 真相。
 - **作用域**：host、agent、session、frontend tree 和 provider Fiber 的状态不能越界；产品级可变状态禁止 module singleton；renderer object 不得进入 domain/session service。
@@ -87,7 +87,7 @@ Every package entry is a Cordis plugin: it exports `name`, optionally `inject`, 
 - **热插拔**：host 持续存活，provider 按 capture -> abort -> dispose -> activate -> restore 替换；激活失败回退 plain provider，不得影响 Agent loop。
 - **新功能接入**：Harness 新能力以 adapter + feature plugin + bundle row + fixture additive 接入；不得把旧架构 UI 直接搬回主线。
 - **验证门禁**：新 surface 必须有官方 consumer、headless fixture、unload/swap、replay/late-result、width-scan、bundle composition 和真实 profile dogfood。
-- **主线同步**：p2/frontend-runtime 定期同步 master；master 的必要 bugfix/Harness bump 直接吸收，旧 Blue UI 功能按新架构重做。
+- **真相分层**：当前代码描述现状，v1 contract 描述目标，matrix/roadmap 描述尚未完成的收敛工作；未通过门禁的 surface 不得写成已发布 Stable。
 
 现有实现文档描述的是当前代码；当新 runtime 尚未迁移某个 surface 时，不得把目标契约写成已落地服务。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,36 +1,51 @@
 # Blue 文档索引
 
-本目录分为**当前文档**和 `history/` **历史存档**。当前文档随代码演进；历史存档保留归档时点原貌。包级细节见各 `packages/*/AGENTS.md`，仓库约定见根 [AGENTS.md](../AGENTS.md)。
+当前实现事实以代码、[blue-architecture.md](./blue-architecture.md)、[blue-seams.md](./blue-seams.md) 和包级 `AGENTS.md` 为准；插件 v1 目标以 [blue-plugin-contract-v1.md](./blue-plugin-contract-v1.md) 为准；PR #77 的收敛状态和 v1 发布顺序分别以 convergence matrix 与 roadmap 为准。`history/` 和阶段设计文档只保留设计理由，不具有规范性。仓库约定见根 [AGENTS.md](../AGENTS.md)。
 
-## 当前架构与迁移控制
+## 规范与目标态
+
+| 文档 | 内容 |
+|---|---|
+| [blue-plugin-contract-v1.md](./blue-plugin-contract-v1.md) | Draft Target：Blue 插件 v1 的规范性契约；不代表全部接口已落地 |
+
+## 当前实现
 
 | 文档 | 内容 |
 |---|---|
 | [blue-architecture.md](./blue-architecture.md) | 当前架构：domain/projection/action/frontend model/TUI adapter 与 composition |
 | [blue-seams.md](./blue-seams.md) | 当前 seam：稳定 plugin host、app session boundary、model registries 与 bundle mapping |
-| [blue-frontend-architecture.md](./blue-frontend-architecture.md) | renderer-neutral frontend runtime 的目标原则 |
 | [blue-session-runtime.md](./blue-session-runtime.md) | projection、action、session reader 与 adapter 职责 |
 | [blue-interaction-model.md](./blue-interaction-model.md) | command、panel、status、dock、editor 与 provider model |
 | [blue-surface-migration-matrix.md](./blue-surface-migration-matrix.md) | surface replacement 与物理删除状态 |
+| [blue-plugin-validation.md](./blue-plugin-validation.md) | architecture validator 和独立 fixture 门禁 |
+| [blue-fixture-audit.md](./blue-fixture-audit.md) | context/remote/openpencil/lark 验证记录 |
+
+## 活跃收敛与发布
+
+| 文档 | 内容 |
+|---|---|
+| [blue-pr77-convergence-matrix.md](./blue-pr77-convergence-matrix.md) | Active Control：PR #77 相对 v1 目标的处理结论、证据与合并门禁 |
+| [blue-plugin-api-v1-roadmap.md](./blue-plugin-api-v1-roadmap.md) | Active Plan：PR #77 合并后到 v1 API 发布的产物顺序与退出条件 |
+| [blue-compatibility-and-rollout.md](./blue-compatibility-and-rollout.md) | Harness 兼容窗口、fallback 与 rollout |
+
+## 阶段设计、研究与历史决策
+
+以下文件仍在顶层以保留现有链接；它们记录阶段方案或研究输入，不覆盖上面的目标契约和当前实现事实。
+
+| 文档 | 内容 |
+|---|---|
+| [blue-frontend-architecture.md](./blue-frontend-architecture.md) | renderer-neutral frontend runtime 的架构原则 |
 | [blue-runtime-cutover-ledger.md](./blue-runtime-cutover-ledger.md) | frozen refs、parity、删除门禁和最终证据 |
 | [blue-frontend-runtime-cutover-spec.md](./blue-frontend-runtime-cutover-spec.md) | cutover 冻结规格和发布边界 |
 | [blue-frontend-runtime-migration-checklist.md](./blue-frontend-runtime-migration-checklist.md) | C0-C7 执行/验收清单 |
 | [blue-implementation-plan.md](./blue-implementation-plan.md) | F0-F6 阶段实施与兼容策略 |
-| [blue-compatibility-and-rollout.md](./blue-compatibility-and-rollout.md) | Harness 兼容窗口、fallback 与 rollout |
-| [blue-plugin-validation.md](./blue-plugin-validation.md) | architecture validator 和独立 fixture 门禁 |
-| [blue-fixture-audit.md](./blue-fixture-audit.md) | context/remote/openpencil/lark 验证记录 |
 | [blue-plugin-ecosystem.md](./blue-plugin-ecosystem.md) | 外部插件分类、安装与 provider lifecycle |
 | [blue-skills-plan.md](./blue-skills-plan.md) | plugin development/migration/fixture/validation skills |
-
-## 产品与历史决策
-
-| 文档 | 内容 |
-|---|---|
-| [blue-api-design.md](./blue-api-design.md) | 公共 API 设计 |
+| [blue-api-design.md](./blue-api-design.md) | 早期公共 API foundation；由 v1 target contract 接替 |
 | [blue-editor-walkthrough.md](./blue-editor-walkthrough.md) | editor contract/implementation/consumer/enhancement 走查 |
 | [blue-roadmap.md](./blue-roadmap.md) | 阶段路线图；早期 seam 名称是历史记录，以当前架构文档为准 |
 | [blue-commands-plan.md](./blue-commands-plan.md) | 内置命令实施记录；旧 `blueSession`/`fold.ts` 描述是当时方案 |
 | [blue-decisions.md](./blue-decisions.md) | ADR 历史；被 cutover 取代的接口不再代表当前代码 |
 | [blue-frontend-runtime-task-checklist.md](./blue-frontend-runtime-task-checklist.md) | F3-F6 已执行任务记录 |
 
-`packages/context`、`packages/remote`、`packages/openpencil` 和 `packages/lark` 是 validation-only packages，不进入 Blue bundle/release closure。正式 package contract 由 `script/package-contract.mjs` 定义。
+`history/` 保留归档时点原貌。`packages/context`、`packages/remote`、`packages/openpencil` 和 `packages/lark` 是 validation-only packages，不进入 Blue bundle/release closure。正式 package contract 由 `script/package-contract.mjs` 定义。

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,13 @@
 # Blue 文档索引
 
-当前实现事实以代码、[blue-architecture.md](./blue-architecture.md)、[blue-seams.md](./blue-seams.md) 和包级 `AGENTS.md` 为准；插件 v1 目标以 [blue-plugin-contract-v1.md](./blue-plugin-contract-v1.md) 为准；PR #77 的收敛状态和 v1 发布顺序分别以 convergence matrix 与 roadmap 为准。`history/` 和阶段设计文档只保留设计理由，不具有规范性。仓库约定见根 [AGENTS.md](../AGENTS.md)。
+当前实现事实以代码、[blue-architecture.md](./blue-architecture.md)、[blue-seams.md](./blue-seams.md) 和包级 `AGENTS.md` 为准；插件 v1 的机器/API 目标以 [blue-plugin-contract-v1.md](./blue-plugin-contract-v1.md) 为准，内部 owner 权限与重载行为以 [blue-plugin-host-lifecycle.md](./blue-plugin-host-lifecycle.md) 为准。[PR #79 / PR #77 合并手册](./blue-pr77-convergence-matrix.md)是从 docs-only 设计基线、PR #77 Beta 合并到后续独立 PR 的执行入口；[roadmap](./blue-plugin-api-v1-roadmap.md)定义阶段出口。PR #79 不发布 runtime、npm package、Website v1 可用性或作者 skill。插件作者的正式入口将在 Public Beta 后由 website「开发手册」承担，不需要先读仓内设计规范。`history/` 和阶段设计文档只保留设计理由，不具有规范性。仓库约定见根 [AGENTS.md](../AGENTS.md)。
 
-## 规范与目标态
+## v1 设计规范
 
 | 文档 | 内容 |
 |---|---|
-| [blue-plugin-contract-v1.md](./blue-plugin-contract-v1.md) | Draft Target：Blue 插件 v1 的规范性契约；不代表全部接口已落地 |
+| [blue-plugin-contract-v1.md](./blue-plugin-contract-v1.md) | Draft Design Source：manifest、七项 Stable capability、版本与发布门；不代表全部接口已落地 |
+| [blue-plugin-host-lifecycle.md](./blue-plugin-host-lifecycle.md) | Draft Internal：control-plane authority、owner generation、registration restore 与 hostile-sibling 边界 |
 
 ## 当前实现
 
@@ -24,8 +25,8 @@
 
 | 文档 | 内容 |
 |---|---|
-| [blue-pr77-convergence-matrix.md](./blue-pr77-convergence-matrix.md) | Active Control：PR #77 相对 v1 目标的处理结论、证据与合并门禁 |
-| [blue-plugin-api-v1-roadmap.md](./blue-plugin-api-v1-roadmap.md) | Active Plan：PR #77 合并后到 v1 API 发布的产物顺序与退出条件 |
+| [blue-pr77-convergence-matrix.md](./blue-pr77-convergence-matrix.md) | Active Handbook：PR #79 发布边界、PR #77 合并 runbook、P1-P9 独立 PR 队列与证据模板 |
+| [blue-plugin-api-v1-roadmap.md](./blue-plugin-api-v1-roadmap.md) | Active Plan：R0-R6 阶段依赖、并行工作流与最终发布门 |
 | [blue-compatibility-and-rollout.md](./blue-compatibility-and-rollout.md) | Harness 兼容窗口、fallback 与 rollout |
 
 ## 阶段设计、研究与历史决策

--- a/docs/blue-plugin-api-v1-roadmap.md
+++ b/docs/blue-plugin-api-v1-roadmap.md
@@ -2,7 +2,7 @@
 
 > 状态：**Active roadmap**
 > 起点：目标契约通过评审，PR #77 以 `1.0.0-beta.1` foundation 合并
-> 终点：`BLUE_API_VERSION 1.0.0`、机器契约、真实 owner、生态 fixture、skills 和中英文文档共同发布
+> 终点：`BLUE_API_VERSION 1.0.0`、机器契约、真实 owner、生态 fixture、skills、可开发 v1 插件的创造模式和中英文文档共同发布
 > 目标契约：[blue-plugin-contract-v1.md](./blue-plugin-contract-v1.md)
 > #77 控制矩阵：[blue-pr77-convergence-matrix.md](./blue-pr77-convergence-matrix.md)
 
@@ -18,6 +18,7 @@
 - public data plane 与 bundle-owned control plane 的权限隔离；
 - synthetic conformance kit 和三种插件形态的真实生态 fixture；
 - 更新后的 plugin-development、plugin-migration、plugin-fixture、plugin-validation skills；
+- 能从会话原型生成、校验并 packed-install v1 插件的 Blue 创造模式；
 - 中英文 manifest、capability、quickstart、migration、testing 和 API reference；
 - 当前/上一 Harness line、packed install、真实 profile 和人工验收证据。
 
@@ -31,7 +32,7 @@
   -> negotiated public host / owner authority
   -> Stable capability owners
   -> synthetic + ecosystem fixtures
-  -> skills
+  -> skills + 创造模式 authoring pipeline
   -> bilingual developer docs
   -> API 1.0.0 release
 ```
@@ -57,7 +58,7 @@ Fixture 与实现按 capability 同步增加；“fixture 阶段”是关闭跨�
 
 ### 实施
 
-截至审计 head `c9e1600`，#77 已完成可保留的 implementation baseline：canonical UI/compiler、panes/overlays、status/status provider、editor extension/provider、split session facade/app owner、consumer lifetime fencing、legacy dock/frontend renderer 删除、六个 runnable examples 与 user kit，以及 checkpoint 化的 current/previous Harness packed 证据。当前 CI 机械复跑 examples，W6-4 在 final head 手工补跑选定 package fixtures；status/editor provider 与 editor extensions 仍须 final-head 重跑。这些都是后续收敛的 seed，不是 Stable v1 结论。
+截至审计 head `c89c714`，#77 已完成可保留的 implementation baseline：canonical UI/compiler、panes/overlays、status/status provider、editor extension/provider、split session facade/app owner、consumer lifetime fencing、legacy dock/frontend renderer 删除，以及由 user kit、六个 runnable plugins 和 composition 组成的八包 example suite。最终候选的 current/previous Harness package fixtures、四条 smoke 和专用 profile自动 dogfood均已刷新；`c89c714` 在直接父提交 `3f0e42b` 上只增加“examples 不进入默认 composition”的 guard。它们是后续收敛的 seed，不是 Stable v1 结论；真人 live acceptance仍 pending。
 
 1. 将 #77 rebase/merge 本规范，按最新 head 重跑矩阵并更新 PR body 的 scope、数字和剩余门禁。
 2. 保留上述成熟 runtime；权限和命名收敛不得退回旧 renderer、dock 或未隔离 session facade。
@@ -75,7 +76,7 @@ Fixture 与实现按 capability 同步增加；“fixture 阶段”是关闭跨�
 - `smoke:pty` 与专用 worktree profile 完成 default、120/80/40 列、pane/overlay、status/editor provider、theme/session swap 和 editor input/completion/submit dogfood。
 - 用户明确 live-test 验收后才合并；合并不等于 API v1 发布。
 
-仓内 examples 只算 Beta/reference packed-distribution 基线：它们仍使用 flat `capabilities[]`、内部文件 `entry`，没有 `form`、required/optional/resources，也不是独立生态消费者，不能提前关闭 R2/R6 或 Stable capability 门禁。
+仓内八包 suite 只算 Beta/reference packed-distribution 基线：六个 runnable plugins 仍使用 flat `capabilities[]`、内部文件 `entry`，没有 `form`、required/optional/resources；user kit 和 composition 也不是第四种 form或独立生态消费者，不能提前关闭 R2/R6 或 Stable capability 门禁。
 
 ## 4. R2：JSON Schema 与 manifest toolchain
 
@@ -225,7 +226,7 @@ fixtureCleaned == true
 
 统一的是场景词表和 capability -> required scenarios 映射，不要求无关 fixture 假跑不适用场景。词表包含 manifest negotiation、resource denial、projection replay/resume、action abort/stale、provider swap/fallback、unload/reload、late callback、20/40/80/120 width、bundle composition、当前/上一 Harness exact line；每个 fixture 的全部 declared/applicable 场景必须执行，`skipped` 仍为空。
 
-#77 的六个 executable examples 继续作为 Beta/reference distribution corpus，但它们仍是 flat `capabilities[]`，没有 `form`、required/optional/resources negotiation，也不是独立生态 package。R6 必须将其迁到目标 schema，并另用真实外部 package 关闭三种 form 与独立消费者门禁；仓内 `blue-user-kit` 组件库和 `blue-ecosystem` composition bundle都不构成第四种 form。
+#77 的六个 executable plugin examples 继续作为 Beta/reference distribution corpus；连同 `blue-user-kit` 和 `blue-ecosystem` composition 是八包 suite。六个 entry 仍是 flat `capabilities[]`，没有 `form`、required/optional/resources negotiation，也不是独立生态 package。R6 必须将其迁到目标 schema，并另用真实外部 package 关闭三种 form 与独立消费者门禁；组件库和 composition bundle都不构成第四种 form。
 
 ### 三形态候选与证据等级
 
@@ -271,7 +272,7 @@ dsh-market 不作为 v1 阻断 fixture。在审计基线 [`d5902420b175`](https:
 
 合作前置是 dsh-market 抽出 typed/versioned renderer-neutral Cordis service/controller，至少覆盖 catalog/search、installed/check、install/update/uninstall/toggle、operation progress/cancel/rollback；同时固定 error taxonomy、policy/authorization 和 lifecycle。Service mutation 接受 AbortSignal、profile scope 和 dsh-market 自己的 authorization context，并由 dsh-market Fiber 持有恢复与 restart 策略；Blue adapter 在调用前消费 Blue user gesture，不能把 Blue token 泄漏进 domain service。Blue 只用 `commands` / `panes` / `overlays` / `notifications.publish` 呈现，成为第一个非 Web consumer。现有 beta Update API 可做受限 update-status pilot，但不能被描述为完整 market 集成。Agent Teams、Browser 等同样作为后续 capability discovery，不阻塞 1.0。
 
-## 9. R7：Skills 与开发者文档
+## 9. R7：Skills、创造模式与开发者文档
 
 Skills 在 API 和 fixture 稳定后更新，避免教会开发者一套过期接口。
 
@@ -284,6 +285,35 @@ Skills 在 API 和 fixture 稳定后更新，避免教会开发者一套过期�
 
 每个 skill 至少有 integrated、adapter、pure-ui 和 zero-API 四类 eval；输出引用生成的 capability catalog，不内嵌名字副本。
 
+### 创造模式 authoring pipeline
+
+现有 `cordis` preset、creative isolate 和真实 `cordis_define/run/update/stop/rollback` e2e作为动态原型底座保留。它们当前仍教授 flat manifest、`^1.0.0`、`session.act`、notification observe与旧 identity，而且测试只验证 skill discovery和动态 runner生命周期，没有执行 bundled skills、生成持久包或运行 packed fixture。R7 必须把创造模式升级为 v1 插件开发入口和 official consumer，而不是增加第四种 plugin form。
+
+目标流程为：
+
+```text
+需求与 zero-API 判断
+  -> inspect + 加载 bundled cordis-plugin-development
+  -> host-minted transient capability request + 动态原型
+  -> 当前会话 UI 验收
+  -> 用户选择 ephemeral / local / GitHub / npm
+  -> 加载 bundled blue-plugin-development
+  -> 生成 v1 package
+  -> shared validator
+  -> current/previous Harness packed fixture
+```
+
+具体交付要求：
+
+1. preset persona、bundled `cordis-plugin-development` / `blue-plugin-development`、仓内四项 plugin skills和中英文文档直接消费发布的 schema、generated capability catalog、TypeScript API与模板；不得复制 capability/version名单。
+2. 动态 `code.host` 使用由同一机器契约生成并经 host校验的 authoring-only transient capability request；creative host分配临时 identity，请求不能伪造 package `entry`、`form` 或 installer receipt。它只能消费获准的 Stable facet和 optional Experimental facet，不能通过 raw Agent/Session、owner registry、`session.act` 或 notification observe延续旧 API。transient prototype不是可发布 entry，也不算一种 form。
+3. 持久化前先判断 zero-API；确需 Blue entry时必须选择 `integrated | adapter | pure-ui`。三种 scaffold分别落实 headless domain/UI scope分离、上游公开 service inject与 adapter删除条件、无 domain dependency，并生成 required/optional/resources、grants检查和逐能力 fallback。
+4. 用户确认前不得写 package、仓库或发布物。确认后生成 `package.json.blue.manifest` pointer、`blue.plugin.json`、public exports/files、Cordis entry和 composition；entry解析同一 JSON，不能保留原型 inline manifest作为第二真相。
+5. 发布一个可在 workspace外直接调用的 versioned scaffold/validator/conformance kit；不能要求插件作者 clone Blue，也不能让 fixture因包不在当前 pnpm workspace而拒绝。生成后自动进入修复循环，直至 validator和双 Harness线 packed fixture均通过且无 skip。
+6. integrated、adapter、pure-ui、zero-API各有 skill eval；negative eval覆盖 HTTP-only业务 closure、raw Agent/Session、被拒绝 capability、Experimental放 required、无 fallback和多余授权。
+
+创造模式门禁必须检查 schema -> generated TS -> runtime validator -> installer -> capability catalog -> templates -> skills/docs 的生成漂移，以及 API/schema/skill/template version stamp一致。preset、skills和模板中回流 flat `capabilities: []`、generic `session.act`、普通 `notifications.subscribe`、旧 identity/entry示例时 CI直接失败。bundle/authoring-kit tarball必须实际携带并可解析其承诺的 schema、catalog、templates和工具。
+
 开发者文档最后生成并保持中文源、英文镜像：
 
 - concepts：三种 form 与四种架构职责；
@@ -294,7 +324,7 @@ Skills 在 API 和 fixture 稳定后更新，避免教会开发者一套过期�
 - testing：validator、packed fixture、previous Harness、width/profile/human gate；
 - API reference：TS declaration、schema URL、error taxonomy 和版本政策。
 
-所有教程样例本身进入 packed fixture。网站 build、链接、中文/英文结构 parity 和 catalog drift 是 CI gate。
+所有教程样例本身进入 packed fixture。网站 build、链接、中文/英文结构 parity、catalog drift 和 creative-mode 教程/模板 drift 是 CI gate。
 
 完成后归档 `blue-api-design.md`、PR #77 的 UI blueprint 和已结束的 frontend-runtime cutover 套件；保留 `blue-frontend-architecture.md` 作为原则、package AGENTS 作为当前实现。归档移动单独提交，统一修复根 AGENTS、`CODEX-IMPLEMENTATION-GUIDE.md` 和 docs links。
 
@@ -306,14 +336,15 @@ Skills 在 API 和 fixture 稳定后更新，避免教会开发者一套过期�
 2. Stable capability catalog 每项 owner/consumer/fallback/fixture complete；
 3. API declaration report 确认 root 无 Experimental/Deferred/control-plane 泄漏；
 4. 三种 form 各至少一个 Stable 生态 fixture、Stable catalog 的逐项证据和 Modlens zero-API negative fixture 在 current/previous Harness line green；候选表中 Experimental/Deferred/blocked 项不计作未完成 blocker；
-5. skills eval 与中英开发者文档 green；
-6. 全仓 test、coverage、typecheck、lint、build、check:lib、check:pack、diagrams、website build 和 smoke green；
-7. 独立 `blue-<tag>` profile 覆盖 install、unload/reload、provider/theme/session swap、120/80/40 列和首批 POC；
-8. 用户 live-test 并明确验收；
-9. 将 API/host version 从 `1.0.0-beta.1` 改为 `1.0.0`，发布 schema stable URL、packages 和 migration notes；
-10. 从 registry 新建干净 profile 做 install smoke，记录 exact artifacts/Harness line。
+5. 四类 skills eval、创造模式生成门禁与中英开发者文档 green；
+6. 创造模式 full e2e 使用实际 bundled `cordis` preset和 bundled skills完成 inspect -> transient prototype -> UI可见 -> 用户确认 -> 生成包 -> shared validator -> `npm pack` -> current/previous Harness独立安装 -> boot/render -> unload/reload；确认前无持久化写入，报告满足 `declared == executed`、`skipped == []`、cleanup成功；
+7. 全仓 test、coverage、typecheck、lint、build、check:lib、check:pack、diagrams、website build 和 smoke green；
+8. 独立 `blue-<tag>` profile 覆盖 install、unload/reload、provider/theme/session swap、120/80/40 列、首批 POC和至少一次真人创造模式原型到本地包流程；
+9. 用户 live-test 并明确验收；
+10. 将 API/host version 从 `1.0.0-beta.1` 改为 `1.0.0`，发布 schema stable URL、packages 和 migration notes；
+11. 从 registry 新建干净 profile 做 install smoke，记录 exact artifacts/Harness line。
 
-任何 skipped fixture、任一已声明 Stable capability 缺少真实 owner、只有 Web route 的业务 API、缺失上一 Harness line、缺失人工验收都阻止 `1.0.0`。Blue 产品 release 仍可保持 `0.x`，不需要为了协议 v1 人为提升产品 major。
+任何 skipped fixture、任一已声明 Stable capability缺少真实 owner、只有 Web route的业务 API、创造模式仍生成旧协议或不能完成持久包双线验证、缺失上一 Harness line、缺失人工验收都阻止 `1.0.0`。Blue 产品 release仍可保持 `0.x`，不需要为了协议 v1人为提升产品 major。
 
 ## 11. 工作方式
 

--- a/docs/blue-plugin-api-v1-roadmap.md
+++ b/docs/blue-plugin-api-v1-roadmap.md
@@ -1,0 +1,315 @@
+# Blue 插件协议 v1 发布路线
+
+> 状态：**Active roadmap**
+> 起点：目标契约通过评审，PR #77 以 `1.0.0-beta.1` foundation 合并
+> 终点：`BLUE_API_VERSION 1.0.0`、机器契约、真实 owner、生态 fixture、skills 和中英文文档共同发布
+> 目标契约：[blue-plugin-contract-v1.md](./blue-plugin-contract-v1.md)
+> #77 控制矩阵：[blue-pr77-convergence-matrix.md](./blue-pr77-convergence-matrix.md)
+
+本文只定义阶段、依赖、产物和退出门。Capability 语义只在目标契约定义；#77 当前状态只在收敛矩阵维护。
+
+## 1. 发布完成定义
+
+协议 v1 不是把 `BLUE_API_VERSION` 常量改成 `1.0.0`。以下产物必须同时完成：
+
+- 可公开引用的 JSON Schema Draft 2020-12；
+- 从 schema 生成的 TypeScript manifest type 和共用 runtime validator；
+- Stable capability 的 public API、resource grant、真实 owner、fallback 和默认 composition；
+- public data plane 与 bundle-owned control plane 的权限隔离；
+- synthetic conformance kit 和三种插件形态的真实生态 fixture；
+- 更新后的 plugin-development、plugin-migration、plugin-fixture、plugin-validation skills；
+- 中英文 manifest、capability、quickstart、migration、testing 和 API reference；
+- 当前/上一 Harness line、packed install、真实 profile 和人工验收证据。
+
+依赖主链：
+
+```text
+规范冻结
+  -> #77 Beta 安全合并
+  -> JSON Schema
+  -> generated TypeScript manifest + capability catalog
+  -> negotiated public host / owner authority
+  -> Stable capability owners
+  -> synthetic + ecosystem fixtures
+  -> skills
+  -> bilingual developer docs
+  -> API 1.0.0 release
+```
+
+Fixture 与实现按 capability 同步增加；“fixture 阶段”是关闭跨包、跨版本和生态总门禁，不是等代码写完才补测试。
+
+## 2. R0：规范 PR
+
+### 产物
+
+- `docs/blue-plugin-contract-v1.md`：长期 Proposed target contract。
+- `docs/blue-pr77-convergence-matrix.md`：临时 merge-control ledger。
+- `docs/blue-plugin-api-v1-roadmap.md`：本路线。
+- `docs/README.md` 与根 `AGENTS.md` 的 Target/Current/Active/Historical 权威指针。
+
+### 退出门
+
+- 三份文档不混写实现进度、长期语义和发布步骤。
+- capability catalog、三种 form、manifest identity、required/optional/resource、Beta/v1 边界已经决策完整。
+- PR #72 的 UI 蓝图和 PR #76 的 capability-gap 调研只作为输入，不与目标契约并列为规范真相。
+
+## 3. R1：PR #77 Beta foundation
+
+### 实施
+
+1. 将 #77 rebase/merge 本规范，按最新 head 重跑矩阵。
+2. 保留 canonical UI、builders/compiler、panes/overlays、status/status provider 和 editor extension runtime。
+3. 将 API/host version 改为 `1.0.0-beta.1`，删除“当前已经 Stable 1.0”的 README/website 表述。
+4. 从 plugin-facing root 移除 owner attach、aggregate snapshot/observe、gesture mint 和强制 close。
+5. 由 bundle composition 创建 canonical owner authority/lease并传给官方 owners；public sibling 即使访问 Cordis `symbols.original` 也不能获得 authority。
+6. 从 Beta public vocabulary 移除 `session.act` 和 Stable `editor.provider`；`session.read` 在真实 owner 前只作为目标文档项，不伪装可协商。
+7. `editor.extensions` 保留实现但标记 Experimental；记录 runtime passive subset 比静态 `BlueUiNode` 更窄的待修项。
+
+### 退出门
+
+- hostile sibling fixture 无法 self-attach、读取 aggregate、observe 全局通知、mint gesture 或关闭别人的 overlay。
+- #77 已有 unit、compile、packed、width evidence 全绿；editor fixture 再穿过真实 input/completion/submit UI。
+- 专用 worktree profile 完成 default、120/80/40 列、provider/theme/session swap 和 editor extension dogfood。
+- 用户明确 live-test 验收后才合并；合并不等于 API v1 发布。
+
+## 4. R2：JSON Schema 与 manifest toolchain
+
+### 单一 shape 真相与语义层
+
+新增 `packages/api/schema/blue.plugin.schema.json`，使用 JSON Schema Draft 2020-12。Schema 是 manifest shape 的唯一机器真相；Schema 加版本化 semantic validator 构成完整机器契约。通过 package export `@dsh-blue/blue-api/schema/blue.plugin.schema.json` 和稳定网站 URL 同时发布。
+
+Schema 必须表达：
+
+- required identity/entry/API/product compatibility/form；
+- `integrated | adapter | pure-ui`；
+- capability `required`/`optional` discriminated request；
+- capability version 和每项专用 `resources`；
+- Stable/Experimental 结构约束；跨数组 name uniqueness 由共享 semantic validator 补充；
+- strict additional properties 和可操作的 validation location。
+
+工具链固定为：
+
+- `json-schema-to-typescript` 只生成 `BluePluginManifest` 数据类型，生成文件不手改；runtime capability callback/API 类型继续由 TypeScript 手写并由 catalog 做 exhaustive check；
+- Ajv 2020 供 API runtime parser、CLI validator 和 installer 共用 schema；
+- `semver` 负责 range parse/intersection，替换字符正则和 API-major 近似；
+- `check:plugin-schema` 重新生成到临时目录并 diff，校验 schema、generated TS、package export/files 和 published copy 无漂移。
+
+`BLUE_CAPABILITY_CATALOG` 用 generated capability-name union 做 exhaustive key，记录 version、stability、resource schema id、owner、scope、fallback 和 limits。网站 capability 表从 catalog 生成或由 drift test 比对，不再手写名字列表。
+
+### Validator 收敛
+
+`script/blue-plugin-validate.mjs` 必须：
+
+1. 从 `package.json.blue.manifest` 找文件，而不是碰巧寻找 root JSON；
+2. 运行同一 schema/semantic validator；
+3. 校验 id=package name、entry=exports subpath、`files` 和 packed tarball；
+4. 根据 `form` 执行依赖/import/headless 规则；
+5. 保留稳定 JSON report code/reproduce，不执行未信任 entry 完成静态阶段。
+
+### 退出门
+
+- positive/negative corpus 覆盖所有字段、form、capability、resource、semver 和 identity 分支。
+- runtime parser、validator、installer 对同一 corpus 结论一致。
+- 仓库至少有三个真实 `blue.plugin.json` 样例，分别覆盖三种 form。
+
+## 5. R3：TypeScript public API 与协商 host
+
+### Public API plane
+
+`@dsh-blue/blue-api` root 只导出 Stable plugin-facing surface：
+
+- `parseBluePluginManifest`、generated manifest types；
+- `BlueResult` 和稳定 error taxonomy；
+- readonly JSON/data/action primitives；
+- `BluePluginHost.open()`、`BluePluginOpen`、grant/unavailable types；
+- Stable `BlueCapabilityApiMap` 和按 grant 裁剪的 `BluePluginApi`。
+
+Experimental editor types从明确的 experimental subpath/namespace 进入，不混入 Stable API report。Owner types MAY 公开用于官方包编译，但 authority value 只能由 bundle composition 创建，且不能从 public host 或 Cordis original 解出。
+
+### Negotiation
+
+- required capability/resource 采用原子 admission；optional 逐项降级并返回原因。
+- grant 返回 exact capability version、实际 resource 和 host limits。
+- capability owner generation 在每次 register/write/action 时复查。
+- error code补齐 resource denied、timeout、stale、unavailable、internal isolation。
+- API declaration report 进入 CI，破坏 Stable surface 必须显式评审。
+
+### 现有 surface 收敛
+
+- `notifications` 拆成 public publish 与 owner-only observe。
+- 所有内置 dock consumer 迁到 bottom pane，物理删除 dock compatibility。
+- 删除 `BluePluginDefinition.apply(api: unknown)`、inline legacy manifest 和 public owner aggregate。
+
+### 退出门
+
+- required/optional/partial-resource、owner absence/reload、cross-plugin isolation 全部有 host fixture。
+- API root 不含 Deferred/owner power；exports/files/tsdown/check:lib 与 packed tarball一致。
+- Beta manifest 有明确迁移错误，不能静默解释成不同权限。
+
+## 6. R4：Stable capability owners
+
+每个 capability 独立 PR/worktree，顺序由依赖决定。
+
+### R4-A：现有 UI authority
+
+收敛 `commands`、`status`、`panes`、`overlays`、`notifications.publish`、`status.provider`：
+
+- 把现有 registry/bridge 接到 negotiated grant；
+- status provider snapshot 去掉隐式 session 信息；
+- limits 从硬编码实现提升为可观察 grant；
+- 每项 owner subscription 按 capability 窄化。
+- 以冻结的 dsh-status-bar minimal provider slice 验证 `status.provider` whole-provider ownership 与 fallback；只有 in-repo reference fixture、没有外部 packed port 时不得标 Stable。
+
+### R4-B：Readonly session/projection
+
+1. 从 `BlueSessionReader` 移除 `request()`，建立纯 readonly `session.read` facet。
+2. snapshot 按 identity/cwd/status/mode/model resource 投影并带 `sessionEpoch/revision`。
+3. 在 app/harness-adapter 建 `projections.read` allowlist gateway；返回一致 cut、`asOfSeq`、有界 immutable value。
+4. session switch、same-id new epoch、key unload、late callback 和 duplicate/older sequence 都有确定结果。
+
+### R4-C：Conversation extension points
+
+- `conversation.read` 提供 cursor/page-size 有界 normalized entries；不暴露 raw event log。
+- `conversation.navigate` 只改变当前 frontend viewport，不修改 session。
+- `conversation.itemActions` 注册 label/applicability/handler；Blue 在 dispatch 前复查 item ref epoch/revision并提供 gesture/signal，插件调用自己的 domain service。
+
+Rewind、Message Edit 和无 domain mutation 的 Bookmark/Tag reference fixture 必须共用该扩展点，禁止为某一个插件新增业务字段。Peak Indicator 走 additive status，不计作 item-action 泛化证据。
+
+### R4-D：Theme 与 settings
+
+- `theme.provider` 注册 semantic token candidate；用户选择、token validation、fallback、unload/swap 与 status provider 同等级。
+- `settings.sections` 只管理 Blue 设置 UI composition；schema/value/commit/conflict/persistence 由插件直接 inject `dsh-settings`。
+- Catppuccin 不能复制 JSON 到 Blue 包，也不能输出 ANSI；它只注册 theme candidate 和可选 settings section。
+
+### 每项退出门
+
+- 至少两个独立消费者（一个 Blue official/reference、一个独立生态包）、absence fallback、Fiber unload 和 package/bundle composition 齐全。
+- read capability 有 replay/resume/stale；action 有 gesture/abort/stale/double-submit；renderer contribution 有 width/failure isolation；provider 有 swap/LKG/breaker/fallback。
+- packed fixture current/previous Harness line 均执行，无 skipped。
+
+## 7. R5：Editor Experimental
+
+在保留 #77 editor runtime 的基础上，按最小权力拆分：
+
+1. `editor.decorations`：先迁 passive before/after、hint、diagnostic、action。
+2. `editor.completions`：独立 trigger/query、mux、timeout、abort、stale 和 result cap。
+3. `editor.draft.read`：revisioned readonly draft snapshot。
+4. `editor.draft.write`：expected revision 的结构化 insert/replace；与 history/IME transaction一致。
+5. `editor.submit.transform`：固定排序、逐项 timeout、abort、rollback，提交清空前完成 barrier。
+
+全部只能 optional，owner/fixture 缺失不阻止插件加载。Composer History 验证 draft read/write 和 session/editor reload；`@/#` completion 与 submit transformer 各自使用独立 fixture。
+
+Composer History 的 v1 fixture 只验证显式 history command/overlay 与 draft read/write，不承诺原 Web 版的 ArrowUp edge recall 或 Ctrl+R。精确按键体验依赖尚未泛化的 contextual editor-key seam，列入 Deferred 独立设计；不得把 raw key handler 塞进上述五个 capability，也不得因此阻断 `1.0.0`。
+
+`editor.provider` 不在本阶段实现。它必须另开设计提案，并在第二个真实 provider、完整 capture/restore 和真人 dogfood 后才可考虑进入 1.x。
+
+## 8. R6：Conformance 与生态 fixture
+
+### Synthetic conformance kit
+
+扩展 `script/blue-plugin-fixture.mjs` 或拆出 versioned kit，使每个测试包从 `npm pack` tarball 在 throwaway npm project 安装，只 import public exports。报告必须保持：
+
+```text
+declared == executed
+skipped == []
+failures == []
+fixtureCleaned == true
+```
+
+统一的是场景词表和 capability -> required scenarios 映射，不要求无关 fixture 假跑不适用场景。词表包含 manifest negotiation、resource denial、projection replay/resume、action abort/stale、provider swap/fallback、unload/reload、late callback、20/40/80/120 width、bundle composition、当前/上一 Harness exact line；每个 fixture 的全部 declared/applicable 场景必须执行，`skipped` 仍为空。
+
+### 三形态候选与证据等级
+
+下表中的 `form` 指目标发布的 Blue entry，不是某个生态项目的固有属性。审计冻结于 2026-08-28/29；commit 是 fixture 可复现基线，不是要求永远跟随的版本。Fixture MAY 暂存于 Blue conformance 仓或固定 commit fork，但必须记录 upstream commit、补丁、同步/删除条件、发布/代码 ownership 和作者合作状态。同一功能若由上游同包发布就是 `integrated`，由独立 `*-blue` 包只消费其 service 则是 `adapter`；fixture manifest 必须按实际 ownership 选择，不能按本表名称猜测。
+
+| Form | 候选与冻结证据 | 目标 Blue 边界 | 当前可行性 | v1 角色 |
+| --- | --- | --- | --- | --- |
+| pure-ui | [Catppuccin](https://github.com/NoNameLeGo/dsh-catppuccin-theme) `a44df0045d81` | 四套 theme JSON -> `theme.provider`；可选 `settings.sections`，持久化走 `dsh-settings` | 高；现有 TUI 会写 `~/.dsh-tui/themes`，新 Blue entry 必须直接注册 semantic tokens，且不得启动 sibling Web/update route | **首批 POC / Stable blocker** |
+| pure-ui | [Conversation Navigator](https://github.com/gjj-star/dsh-conversation-navigator) `9682972130d8` | `conversation.read`、`conversation.navigate`、`session.read`、`panes`，可选 `commands` / `settings.sections` | 高；当前 browser entry 与空 host shell 已分离，重点是分页、session switch、stale jump、width | 第二波 Stable evidence |
+| pure-ui | [Composer History](https://github.com/PerryLink/dsh-composer-history) `16feb04aaaaf` | Experimental `editor.draft.read/write`、`conversation.read`、`overlays`、`settings.sections` | 中；v1 只迁显式 history/draft 子集，ArrowUp/Ctrl+R 等 contextual key seam Deferred | Experimental，**不阻断 1.0** |
+| adapter | [Cost Meter](https://github.com/Han-1413141/dsh-cost-meter) `56455e17848d` | 独立 Blue adapter 直接 inject 公开 `costMeter` service，并申请 `projections.read` resource `{ keys: ['costUsage'] }`；只向 `status` / `panes` / `commands` / `notifications.publish` / `settings.sections` 投影 | 高；已有公开 service 和 projection，不产生 `cost.*` Blue capability，也不复制费用真相 | **首批 POC / Stable blocker** |
+| adapter | [Turn Rewind](https://github.com/Anionex/dsh-turn-rewind) `d3734cb183a5` | 独立 Blue adapter inject `rewind` service 后消费 `conversation.itemActions`、`overlays` | 阻塞；当前只有 `/rewind` command 和 raw Agent/Session 执行。作者需先抽 `list/preview/execute` renderer-neutral service；若 Blue face 改由上游同包拥有，form 应改为 integrated | 前置条件项；可由 Message Edit + Bookmark/Tag reference 补其 v1 证据 |
+| integrated | [dsh-context](https://github.com/bowenliang123/dsh-context) `6d17588a5672` | 同包 headless projection 与独立 Blue entry；消费 `projections.read` / `status` / `panes` / `overlays` / `commands` / `settings.sections` | 高；先做 headline、composition、recent events，不复制完整 Web dashboard | **首批 POC / Stable blocker** |
+| integrated | [OpenPencil](https://github.com/ZSeven-W/dsh-openpencil) `906ff9c2fcda` | domain/tool 继续 headless；Blue v1 只验证 canonical text/diff fallback、signed-meta elision 和 `notifications.publish` | 当前 `@dsh-blue/blue-openpencil` 是独立 adapter；本行只在上游作者拥有同包 Blue entry 后成立。Rich workbench 依赖 Deferred tool-presentation，不能搬 Web canvas 或 capability bearer | v1 negative/fallback；rich UI 不阻断 1.0 |
+| integrated | [Lark](https://github.com/sugarforever/dsh-lark) `ee639df50fc7` | 上游同包 Blue entry 消费 `commands` / `notifications.publish` / `settings.sections`；domain runtime 独立 | 当前 `@dsh-blue/blue-lark` 是 loopback HTTP compatibility adapter，不是 integrated。上游公开 service/内置 Blue face 后删除 adapter | 未来 integrated，非首批 blocker |
+
+表外另保留两条不同性质的证据：
+
+- [Blue Remote](https://github.com/GeekCmore/dsh-remote) `423c736869aa` 是 transport/protocol infrastructure fixture，验证 negotiate、seq resume、lease、question/approval、reconnect 和 unload。它当前不消费 Stable UI capability，因此不冒充三种 Blue plugin form；待 Deferred session/frontend provider 契约再重新分类。该项目也不能与市场中同名 remote 包混淆。
+- [Modlens](https://github.com/liustack/modlens) `147356e6dde0` 是 zero-Blue-API negative fixture：它继续只通过 Harness tool/provider 工作，Blue 无 manifest、无专用 capability 也能呈现通用结果。该用例防止“为了市场覆盖给每个 domain 发明 capability”。
+
+Conversation item-action 的外部压力基线另冻结为 [Message Edit](https://github.com/Moeblack/dsh-message-edit) `b78a167064ca`，但它与 Rewind 一样要先抽 renderer-neutral service。Bookmark/Tag 是明确标记的 in-repo reference fixture，不伪装成外部生态消费者；创建时记录自身 commit。
+
+[dsh-status-bar](https://github.com/Starlight-bananice/dsh-status-bar) `128a7f3d1256` 是 `status.provider` 的独立生态候选。首个 fixture 严格限定为 minimal pure-ui provider slice，只消费 `session.read` 的 status/cwd/mode/model 和 sanitized additive entries；完整 17 段与费用历史版是后续 integrated 目标，需要 allowlisted `projections.read`，并先把 JSONL/HTTP ledger 抽成 renderer-neutral Cordis service。只有该外部 slice 通过 packed/provider-swap/width 门禁后，才满足 Stable 的外部消费者条件。
+
+[Peak Indicator](https://github.com/future007s/dsh-peak-indicator) `887bbe7040f1` 是 additive `status` 候选，只验证峰谷时段徽标与 timer/unload；它不替代 `status.provider`，也不计作 conversation item-action consumer。
+
+候选池是 discovery/fixture portfolio，不是等权 release blocker。`1.0.0` 的硬门是三种 form 各至少一个 Stable packed fixture、每个 Stable capability 的 owner/consumer/fallback/lifecycle 证据，以及所有声明场景零 skip；Experimental、Deferred 或明确阻塞的候选不因尚未迁移而阻止发布。反过来，首批三个 POC 也不能替代它们没有覆盖的 Stable conversation/provider 证据，或另行声明的 editor Experimental 证据。
+
+### 首批 POC
+
+按实现风险优先完成：
+
+1. Catppuccin：最快证明 pure UI/theme provider；
+2. Cost Meter：证明公开 service/projection 的窄 adapter；
+3. dsh-context：证明 integrated projection 到 TUI。
+
+选择依据来自 dsh-market 2026-08-28 registry snapshot：Catppuccin 为 20 stars / 5,806 downloads，Cost Meter 为 195 / 17,152，dsh-context 为 1,037 / 32,099。三者兼顾可见用户量和低到中等迁移风险，且不会用同一 capability 的三个变体冒充架构覆盖。
+
+三者 packed fixture 通过后再联系作者。每个合作包携带 frozen upstream commit、可安装 tarball、可运行 profile patch、迁移 diff、短终端录屏、machine-readable fixture JSON、fallback 表和建议代码 ownership，而不是只发送合作设想。它们共同作为联系 dsh-market 的 Blue 能力 demo。下载量是快照中的相对优先级信号，不是协议或长期流量承诺。
+
+dsh-market 不作为 v1 阻断 fixture。在审计基线 [`d5902420b175`](https://github.com/dsh-market/dsh-market/commit/d5902420b175) 中，catalog/安装/profile 更新仍主要封在 HTTP routes；Update API v1 仍为 beta，范围只覆盖 check/start/observe/rollback/restart，不足以支撑完整 TUI 市场。Blue 不能调用私有 route、复制 pnpm/profile/restart 逻辑或定义 `market.install` capability。
+
+合作前置是 dsh-market 抽出 typed/versioned renderer-neutral Cordis service/controller，至少覆盖 catalog/search、installed/check、install/update/uninstall/toggle、operation progress/cancel/rollback；同时固定 error taxonomy、policy/authorization 和 lifecycle。Service mutation 接受 AbortSignal、profile scope 和 dsh-market 自己的 authorization context，并由 dsh-market Fiber 持有恢复与 restart 策略；Blue adapter 在调用前消费 Blue user gesture，不能把 Blue token 泄漏进 domain service。Blue 只用 `commands` / `panes` / `overlays` / `notifications.publish` 呈现，成为第一个非 Web consumer。现有 beta Update API 可做受限 update-status pilot，但不能被描述为完整 market 集成。Agent Teams、Browser 等同样作为后续 capability discovery，不阻塞 1.0。
+
+## 9. R7：Skills 与开发者文档
+
+Skills 在 API 和 fixture 稳定后更新，避免教会开发者一套过期接口。
+
+| Skill | 必须更新的行为 |
+| --- | --- |
+| `plugin-development` | 选择三种 form、生成 package pointer/manifest、区分 direct inject 与 Blue capability、required/optional/resource/fallback |
+| `plugin-migration` | 输出 Domain/Projection/Action/UI/Composition、form、scope、adapter 删除条件；识别 HTTP closure 和不需要 Blue API 的插件 |
+| `plugin-fixture` | 生成 packed current/previous-line 场景；按 capability 自动选择 replay/abort/stale/swap/width/unload；禁止 skipped 充当证据 |
+| `plugin-validation` | schema、public/control plane、package export/files/tsdown、Fiber、bundle/profile/human acceptance 一体门禁 |
+
+每个 skill 至少有 integrated、adapter、pure-ui 和 zero-API 四类 eval；输出引用生成的 capability catalog，不内嵌名字副本。
+
+开发者文档最后生成并保持中文源、英文镜像：
+
+- concepts：三种 form 与四种架构职责；
+- manifest：schema、identity、entry、compatibility、capability negotiation；
+- capabilities：生成的 Stable/Experimental 表、resource/fallback；
+- quickstart：三个最小样例，实际包含 `blue.plugin.json` 并从 tarball 安装；
+- migration：从 flat Beta manifest、dock、notifications、session/editor 旧面迁移；
+- testing：validator、packed fixture、previous Harness、width/profile/human gate；
+- API reference：TS declaration、schema URL、error taxonomy 和版本政策。
+
+所有教程样例本身进入 packed fixture。网站 build、链接、中文/英文结构 parity 和 catalog drift 是 CI gate。
+
+完成后归档 `blue-api-design.md`、PR #77 的 UI blueprint 和已结束的 frontend-runtime cutover 套件；保留 `blue-frontend-architecture.md` 作为原则、package AGENTS 作为当前实现。归档移动单独提交，统一修复根 AGENTS、`CODEX-IMPLEMENTATION-GUIDE.md` 和 docs links。
+
+## 10. R8：`1.0.0` 发布门禁
+
+按以下顺序关闭：
+
+1. schema、generated TS、runtime/validator/installer corpus green；
+2. Stable capability catalog 每项 owner/consumer/fallback/fixture complete；
+3. API declaration report 确认 root 无 Experimental/Deferred/control-plane 泄漏；
+4. 三种 form 各至少一个 Stable 生态 fixture、Stable catalog 的逐项证据和 Modlens zero-API negative fixture 在 current/previous Harness line green；候选表中 Experimental/Deferred/blocked 项不计作未完成 blocker；
+5. skills eval 与中英开发者文档 green；
+6. 全仓 test、coverage、typecheck、lint、build、check:lib、check:pack、diagrams、website build 和 smoke green；
+7. 独立 `blue-<tag>` profile 覆盖 install、unload/reload、provider/theme/session swap、120/80/40 列和首批 POC；
+8. 用户 live-test 并明确验收；
+9. 将 API/host version 从 `1.0.0-beta.1` 改为 `1.0.0`，发布 schema stable URL、packages 和 migration notes；
+10. 从 registry 新建干净 profile 做 install smoke，记录 exact artifacts/Harness line。
+
+任何 skipped fixture、未实现 owner、只有 Web route 的业务 API、缺失上一 Harness line、缺失人工验收都阻止 `1.0.0`。Blue 产品 release 仍可保持 `0.x`，不需要为了协议 v1 人为提升产品 major。
+
+## 11. 工作方式
+
+- 每个阶段使用独立 worktree 和小 PR；不把所有收敛重新塞回 #77。
+- 每个 capability PR 同时改 code、tests、package AGENTS、bundle row、fixture 和当前实现文档。
+- 目标契约变更必须先通过协议评审；实现进度只更新矩阵/roadmap。
+- 用户可见行为按仓库规则安装到 worktree 专属 profile，真人验收前不合并、不删除 profile。
+- 路线完成后本文归档到 `docs/history/`，由 release notes 和生成 API reference 接替。

--- a/docs/blue-plugin-api-v1-roadmap.md
+++ b/docs/blue-plugin-api-v1-roadmap.md
@@ -1,355 +1,222 @@
-# Blue 插件协议 v1 发布路线
+# Blue 插件 API v1 发布路线
 
 > 状态：**Active roadmap**
-> 起点：目标契约通过评审，PR #77 以 `1.0.0-beta.1` foundation 合并
-> 终点：`BLUE_API_VERSION 1.0.0`、机器契约、真实 owner、生态 fixture、skills、可开发 v1 插件的创造模式和中英文文档共同发布
-> 目标契约：[blue-plugin-contract-v1.md](./blue-plugin-contract-v1.md)
-> #77 控制矩阵：[blue-pr77-convergence-matrix.md](./blue-pr77-convergence-matrix.md)
+> 起点：PR #77 按最小 Beta 安全门合并
+> 终点：插件协议 `1.0.0`、对应 Blue `0.x`、创造模式、开发手册和生态验证共同发布
+> API 语义：[设计规范](./blue-plugin-contract-v1.md)
+> 合并与独立 PR 顺序：[PR #79 / PR #77 合并手册](./blue-pr77-convergence-matrix.md)
 
-本文只定义阶段、依赖、产物和退出门。Capability 语义只在目标契约定义；#77 当前状态只在收敛矩阵维护。
+本文只定义阶段、并行工作流、交付物和退出门。每个实际 PR 的范围、顺序和 acceptance record 以合并手册为准。项目名单不表达规模、地位、流量或合作优先级；每个生态项目使用同一套技术与沟通标准。
 
-## 1. 发布完成定义
+## 1. 完成定义
 
-协议 v1 不是把 `BLUE_API_VERSION` 常量改成 `1.0.0`。以下产物必须同时完成：
+协议 v1 不是只修改 `BLUE_API_VERSION`。发布必须同时具备：
 
-- 可公开引用的 JSON Schema Draft 2020-12；
-- 从 schema 生成的 TypeScript manifest type 和共用 runtime validator；
-- Stable capability 的 public API、resource grant、真实 owner、fallback 和默认 composition；
-- public data plane 与 bundle-owned control plane 的权限隔离；
-- synthetic conformance kit 和三种插件形态的真实生态 fixture；
-- 更新后的 plugin-development、plugin-migration、plugin-fixture、plugin-validation skills；
-- 能从会话原型生成、校验并 packed-install v1 插件的 Blue 创造模式；
-- 中英文 manifest、capability、quickstart、migration、testing 和 API reference；
-- 当前/上一 Harness line、packed install、真实 profile 和人工验收证据。
+- JSON Schema Draft 2020-12、generated TypeScript、共享 runtime/semantic validator；
+- 七项 Stable capability 的 public API、resource grant、真实 owner 与 fallback；
+- plugin-facing data plane 与内部 management authority 的权限隔离；
+- product version -> protocol version 的机器映射；
+- 独立 `npm pack` conformance kit 和真实 Harness 插件 fixture；
+- 可生成并验证本地持久包的创造模式；
+- 维护者 outreach skill 与作者 `blue-plugin-development` skill；
+- website 中按任务递进的中英文开发手册；
+- 当前/上一 Harness line、真实 profile 和人工验收证据。
 
-依赖主链：
+主线顺序：
 
 ```text
-规范冻结
-  -> #77 Beta 安全合并
-  -> JSON Schema
-  -> generated TypeScript manifest + capability catalog
-  -> negotiated public host / owner authority
-  -> Stable capability owners
-  -> synthetic + ecosystem fixtures
-  -> skills + 创造模式 authoring pipeline
-  -> bilingual developer docs
-  -> API 1.0.0 release
+PR #79 设计基线
+  -> PR77 Beta 安全合并
+  -> 最小七能力 Beta schema/API
+  -> 生态验证 + 创造模式 + skills + 开发手册（并行）
+  -> 按真实使用证据晋升 Stable
+  -> dsh-market Beta 合作
+  -> protocol 1.0.0 + Blue 0.x + 创造模式发布
 ```
 
-Fixture 与实现按 capability 同步增加；“fixture 阶段”是关闭跨包、跨版本和生态总门禁，不是等代码写完才补测试。
+Fixture 与 capability 同步建设，不在实现结束后补测试。作者联系与技术 conformance 是两条独立记录。
 
-## 2. R0：规范 PR
+执行批次与路线阶段的对应关系固定为：
+
+| 路线阶段 | 合并手册批次 | 含义 |
+| --- | --- | --- |
+| R0 | PR #79 | 只合并 Draft 设计与控制文档 |
+| R1 | PR #77 | 只合并 Beta runtime foundation |
+| R2 | P1-P4 | 机器契约、Host 协商、UI 与 session capability Beta |
+| R3 | P5-P6 | 作者工具/文档、创造模式与生态验证 |
+| R4 | P7 | 按 capability 独立晋升 Stable |
+| R5 | P8 | dsh-market Beta 合作 |
+| R6 | P9 | 协议 `1.0.0` 与对应 artifacts 发布 |
+
+## 2. R0：PR #79 设计基线
 
 ### 产物
 
-- `docs/blue-plugin-contract-v1.md`：长期 Proposed target contract。
-- `docs/blue-pr77-convergence-matrix.md`：临时 merge-control ledger。
-- `docs/blue-plugin-api-v1-roadmap.md`：本路线。
-- `docs/README.md` 与根 `AGENTS.md` 的 Target/Current/Active/Historical 权威指针。
+- API v1 设计规范：机器契约与 Stable 边界。
+- Host 生命周期规范：内部权限、generation 和重载行为。
+- PR #79 / PR #77 合并手册：发布边界、Beta merge control 和后续独立 PR 队列。
+- 本路线图：阶段与退出门。
+- `docs/README.md` 与根 `AGENTS.md` 的权威指针。
+
+### 发布边界
+
+R0 只把 Draft/Active 文档和必要的根 `AGENTS.md` 指针合入 `master`。它不修改 runtime、package/API version、website、创造模式、skill、schema、validator、example 或 bundle，也不发布 npm、Pages 上的可用性承诺或任何外部邀请。完整边界和 PR #79 自身检查见[合并手册“PR #79 的发布边界”](./blue-pr77-convergence-matrix.md)。
 
 ### 退出门
 
-- 三份文档不混写实现进度、长期语义和发布步骤。
-- capability catalog、三种 form、manifest identity、required/optional/resource、Beta/v1 边界已经决策完整。
-- PR #72 的 UI 蓝图和 PR #76 的 capability-gap 调研只作为输入，不与目标契约并列为规范真相。
+- Stable 只包含 `commands`、`status`、`panes`、`overlays`、`notifications.publish`、`session.read`、`session.projections.read`。
+- manifest 没有 `form`；架构职责和迁移模式不成为运行时分类。
+- 公开术语与 Harness 对齐，内部 control-plane 术语不进入 quickstart。
+- PR77 只承担最小 Beta 安全门，不被迫实现全部 v1。
+- 生态项目不按规模、下载量、地位或响应概率分层。
+- PR #79 diff 不包含 `website/`、packages、presets、skills 或 runtime artifacts。
 
 ## 3. R1：PR #77 Beta foundation
 
-### 实施
+截至 `9a6a255`，#77 的 W1-W6 运行候选 `cf8b3bd` 已完成自动证据和用户验收。R1 在该基础上只关闭已知越权和错误 Stable 承诺：
 
-截至审计 head `c89c714`，#77 已完成可保留的 implementation baseline：canonical UI/compiler、panes/overlays、status/status provider、editor extension/provider、split session facade/app owner、consumer lifetime fencing、legacy dock/frontend renderer 删除，以及由 user kit、六个 runnable plugins 和 composition 组成的八包 example suite。最终候选的 current/previous Harness package fixtures、四条 smoke 和专用 profile自动 dogfood均已刷新；`c89c714` 在直接父提交 `3f0e42b` 上只增加“examples 不进入默认 composition”的 guard。它们是后续收敛的 seed，不是 Stable v1 结论；真人 live acceptance仍 pending。
+1. API/host version 改为 `1.0.0-beta.1`，同步 README、website、examples、release note 和 skills。
+2. 移除 public generic `session.act`；内部 dispatcher 不成为普通 sibling service。
+3. notification consumer 只保留 publish；observe 属官方 owner。
+4. owner attach/aggregate/gesture/close helper 退出 plugin-facing root。
+5. raw session/projection backing service不可由普通 sibling直接取得。
+6. editor/status provider 与 editor extension 保留 reference runtime，但退出 Stable root。
+7. 保留 canonical compiler、managed panes/overlays、status、provider/editor runtime、lifetime fencing 和 packed suite。
 
-1. 将 #77 rebase/merge 本规范，按最新 head 重跑矩阵并更新 PR body 的 scope、数字和剩余门禁。
-2. 保留上述成熟 runtime；权限和命名收敛不得退回旧 renderer、dock 或未隔离 session facade。
-3. 将 API/host version 改为 `1.0.0-beta.1`，删除“当前已经 Stable 1.0”的 README/website/release-note 表述。
-4. 从 plugin-facing root 移除 owner attach、aggregate snapshot/observe、gesture mint 和强制 close。
-5. 由 bundle composition 创建 canonical owner authority/lease并传给官方 owners；public sibling 即使访问 Cordis `symbols.original` 也不能获得 authority。
-6. 从 Beta public vocabulary 移除 generic `session.act`，并隐藏或 authority-gate当前可直接 inject 的 raw session/projection reader与 requester；保留 negotiated readonly `session.read` seed但明确其 resource/epoch 尚待 v1 收敛。
-7. 修正 editor extension static/runtime node 集合，并把 provider限定为 host-owned editor engine 外层 shell。R1 的 flat manifest尚不能表达 optional，因此两者先退出 public Beta manifest、仅保留 bundle-internal/reference runtime；R2/R3 negotiated optional plane落地后再以 Experimental 公开，不能只改稳定性标签。
-8. 将 `notifications` 拆为 public publish 与 authority-protected owner observe；普通 consumer 不得订阅全局通知。
+R1 只冻结可观察权限结果，不强制特定 authority representation。hardening 后的新 exact head 必须重跑双 Harness fixture、smoke、worktree profile 和受影响的真人回归；合并不等于 v1 发布。
 
-### 退出门
+## 4. R2：最小 Beta 机器契约与 capability
 
-- hostile sibling fixture 无法 self-attach、读取 aggregate、observe 全局通知、mint gesture 或关闭别人的 overlay。
-- #77 已有 unit、compile、packed、width 和 `smoke:happy` evidence 继续全绿；权限修改后的 final head重跑相关双 Harness 线 fixture。
-- `smoke:pty` 与专用 worktree profile 完成 default、120/80/40 列、pane/overlay、status/editor provider、theme/session swap 和 editor input/completion/submit dogfood。
-- 用户明确 live-test 验收后才合并；合并不等于 API v1 发布。
+R2 按合并手册拆为 P1-P4，不得放进一个大 PR：P1 建机器真相，P2 建协商与权限，P3/P4 才把 UI 和 session capability 接到该契约。
 
-仓内八包 suite 只算 Beta/reference packed-distribution 基线：六个 runnable plugins 仍使用 flat `capabilities[]`、内部文件 `entry`，没有 `form`、required/optional/resources；user kit 和 composition 也不是第四种 form或独立生态消费者，不能提前关闭 R2/R6 或 Stable capability 门禁。
+### Schema 与 package
 
-## 4. R2：JSON Schema 与 manifest toolchain
+- `package.json.blue.manifest` 是唯一 discovery pointer。
+- `blue.plugin.json` 包含 identity、public exports entry、API/product compatibility、required/optional capability 与判别式 resources，不含 `form`。
+- schema 使用 Draft 2020-12 和 `additionalProperties: false`。
+- generated manifest type 不手改；semver 使用正式实现，不用正则近似。
+- runtime parser、CLI validator、installer 和 website examples 共用同一 corpus。
+- validator 检查 id=package name、entry=exports subpath、`files`、tarball 和 peer closure。
 
-### 单一 shape 真相与语义层
+### Catalog 与 host
 
-新增 `packages/api/schema/blue.plugin.schema.json`，使用 JSON Schema Draft 2020-12。Schema 是 manifest shape 的唯一机器真相；Schema 加版本化 semantic validator 构成完整机器契约。通过 package export `@dsh-blue/blue-api/schema/blue.plugin.schema.json` 和稳定网站 URL 同时发布。
+- generated capability-name union只含七项 Stable；Beta/Experimental 不进入 Stable root。
+- catalog记录 version、resource schema、owner、scope、limits、registration restore 和 unavailable fallback。
+- required 原子准入；optional 可缺失或获得 resource 子集；host 返回 exact grants。
+- API declaration report阻止 owner-only、Deferred 或 raw backing types 泄漏。
+- 发布 immutable schema/API subpath 和 product/protocol mapping。
 
-Schema 必须表达：
+### Capability Beta
 
-- required identity/entry/API/product compatibility/form；
-- `integrated | adapter | pure-ui`；
-- capability `required`/`optional` discriminated request；
-- capability version 和每项专用 `resources`；
-- Stable/Experimental 结构约束；跨数组 name uniqueness 由共享 semantic validator 补充；
-- strict additional properties 和可操作的 validation location。
-
-工具链固定为：
-
-- `json-schema-to-typescript` 只生成 `BluePluginManifest` 数据类型，生成文件不手改；runtime capability callback/API 类型继续由 TypeScript 手写并由 catalog 做 exhaustive check；
-- Ajv 2020 供 API runtime parser、CLI validator 和 installer 共用 schema；
-- `semver` 负责 range parse/intersection，替换字符正则和 API-major 近似；
-- `check:plugin-schema` 重新生成到临时目录并 diff，校验 schema、generated TS、package export/files 和 published copy 无漂移。
-
-`BLUE_CAPABILITY_CATALOG` 用 generated capability-name union 做 exhaustive key，记录 version、stability、resource schema id、owner、scope、fallback 和 limits。网站 capability 表从 catalog 生成或由 drift test 比对，不再手写名字列表。
-
-### Validator 收敛
-
-`script/blue-plugin-validate.mjs` 必须：
-
-1. 从 `package.json.blue.manifest` 找文件，而不是碰巧寻找 root JSON；
-2. 运行同一 schema/semantic validator；
-3. 校验 id=package name、entry=exports subpath、`files` 和 packed tarball；
-4. 根据 `form` 执行依赖/import/headless 规则；
-5. 保留稳定 JSON report code/reproduce，不执行未信任 entry 完成静态阶段。
+- `commands`、`status`、`panes`、`overlays`、`notifications.publish` 原则上逐项 PR 接入 grant、limits、fallback 和 owner lifecycle。
+- `session.read` 与 `session.projections.read` 分开 PR 收敛 fields/key grant、session epoch、seq、一致 cut 和 size bound。
+- provider、editor、conversation、theme/settings 和 market operation 不因 PR #77 已有 runtime 自动进入 v1 root。
 
 ### 退出门
 
-- positive/negative corpus 覆盖所有字段、form、capability、resource、semver 和 identity 分支。
-- runtime parser、validator、installer 对同一 corpus 结论一致。
-- 仓库至少有三个真实 `blue.plugin.json` 样例，分别覆盖三种 form。
+- positive/negative corpus覆盖 identity、entry、semver、required/optional、resource、unknown field和重复 capability。
+- schema、generated TS、runtime、validator、installer、templates和website无漂移。
+- workspace 外包可直接运行 validator 和 packed fixture，不要求 clone Blue。
+- 每个已开放 Beta capability 有真实 owner、plain fallback 和适用的 unload/reload/width/abort/replay/stale fixture；未完成的 capability 保持 unavailable，不能伪装 grant。
 
-## 5. R3：TypeScript public API 与协商 host
+## 5. R3：并行真实反馈
 
-### Public API plane
+P1/P2 完成且至少一个 P3/P4 capability 形成可运行 Public Beta 后，按 capability 同时开启四条工作流；不能先冻结宽 API 再等待末期验证。作者手册和 skill 只能描述当时机器 catalog 实际开放的能力。
 
-`@dsh-blue/blue-api` root 只导出 Stable plugin-facing surface：
+### 5.1 生态验证与协作
 
-- `parseBluePluginManifest`、generated manifest types；
-- `BlueResult` 和稳定 error taxonomy；
-- readonly JSON/data/action primitives；
-- `BluePluginHost.open()`、`BluePluginOpen`、grant/unavailable types；
-- Stable `BlueCapabilityApiMap` 和按 grant 裁剪的 `BluePluginApi`。
+首批六个项目采用同一标准：固定 upstream commit、记录公开边界、只使用 v1 候选七项中当时已开放的 Beta capability、独立 packed fixture、相同邀请 Issue 模板和相同作者 skill 链接。
 
-Experimental editor types从明确的 experimental subpath/namespace 进入，不混入 Stable API report。Owner types MAY 公开用于官方包编译，但 authority value 只能由 bundle composition 创建，且不能从 public host 或 Cordis original 解出。
+| 项目 | 当前公开边界 | Blue v1 验证切片 | 技术前置条件 |
+| --- | --- | --- | --- |
+| [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | headless tools、持久团队状态、scheduler、command、Web 私有 routes/internals | `commands`、`status`、`panes`、`overlays` | 先由上游拥有 renderer-neutral Service Definition 或 session projection；不得读 `.agent-teams`、private route 或 package internal |
+| [dsh-context](https://github.com/bowenliang123/dsh-context) | `contextTimeline` / `contextHeaders` session projections 与公开 types | `session.projections.read`、`commands`、`status`、`panes`、`overlays` | 保持 Host projection 为唯一真相，Blue entry 不复制 Web dashboard state |
+| [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) | `costUsage` session projection 与公开 `costMeter` Service | `session.projections.read`、`status`、`panes`、`notifications.publish` | 直接 inject Service；不发明 `cost.*` Blue capability |
+| [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) | 公开 `mcpPanel` Service、Typert invocations 与 `/mcp` | `commands`、`status`、`panes`、`overlays` | v1 先做只读状态/诊断切片，写操作继续由插件 Service 与 Harness approval 所有 |
+| [dsh-notifier](https://github.com/wingsky-1/dsh-plugin-hub/tree/main/packages/dsh-notifier) | Host 事件判断、免打扰和历史；browser half 走 SSE/HTTP | `notifications.publish`、`panes`、`overlays` | 抽取窄的 renderer-neutral Service/subscription；Blue 不消费 private Web routes |
+| [dsh-peak-indicator](https://github.com/future007s/dsh-peak-indicator) | `peakCost` session projection 与独立 browser half | `session.projections.read`、`status`、`panes` | 复用 projection；timer/registration 绑定 Fiber，不把 Web visual effects带进 TUI |
 
-### Negotiation
+每个项目的 fixture MAY 位于固定 fork或 conformance workspace，但必须记录 upstream commit、patch、同步/删除条件和代码 ownership。Blue 默认只发邀请 Issue，不向上游提交未经邀请的代码 PR。作者认可与互荐是生态目标，但不作为确定性 v1 release gate。
 
-- required capability/resource 采用原子 admission；optional 逐项降级并返回原因。
-- grant 返回 exact capability version、实际 resource 和 host limits。
-- capability owner generation 在每次 register/write/action 时复查。
-- error code补齐 resource denied、timeout、stale、unavailable、internal isolation。
-- API declaration report 进入 CI，破坏 Stable surface 必须显式评审。
+### 5.2 创造模式
 
-### 现有 surface 收敛
-
-- `notifications` 拆成 public publish 与 owner-only observe。
-- #77 已将所有内置 dock consumer 迁到 bottom pane并物理删除 dock runtime/type/aggregate/bridge；本阶段只保留旧 manifest 的可操作迁移诊断和 `rg`/schema drift gate，禁止 compatibility 回流。
-- 删除 `BluePluginDefinition.apply(api: unknown)`、inline legacy manifest 和 public owner aggregate。
-
-### 退出门
-
-- required/optional/partial-resource、owner absence/reload、cross-plugin isolation 全部有 host fixture。
-- API root 不含 Deferred/owner power；exports/files/tsdown/check:lib 与 packed tarball一致。
-- Beta manifest 有明确迁移错误，不能静默解释成不同权限。
-
-## 6. R4：Stable capability owners
-
-每个 capability 独立 PR/worktree，顺序由依赖决定。
-
-### R4-A：现有 UI authority
-
-收敛 `commands`、`status`、`panes`、`overlays`、`notifications.publish`、`status.provider`：
-
-- 把现有 registry/bridge 接到 negotiated grant；
-- status provider snapshot 去掉隐式 session 信息；
-- limits 从硬编码实现提升为可观察 grant；
-- 每项 owner subscription 按 capability 窄化。
-- 以冻结的 dsh-status-bar minimal provider slice 验证 `status.provider` whole-provider ownership 与 fallback；只有 in-repo reference fixture、没有外部 packed port 时不得标 Stable。
-
-### R4-B：Readonly session/projection
-
-1. 保留 #77 已拆出的 `session.read` readonly facade：public consumer 只有 `current/subscribe`。followup/steer/interrupt dispatcher MAY 继续作为 app owner内部实现，但当前通用 `BlueSessionRequester` Cordis service必须删除或改为 composition authority-gated，普通 sibling不能 inject；它 MUST NOT 重新进入 reader、公开 service或 public capability vocabulary。
-2. snapshot 按 identity/cwd/status/mode/model grant 投影并带显式 `sessionEpoch/revision`；订阅 replay、stale 判断和 action reference都以 epoch为界。
-3. 在 app/harness-adapter 建 `projections.read` allowlist gateway；返回一致 cut、`asOfSeq`、有界 immutable value。
-4. session switch、same-id new epoch、resource denial、key unload、late callback 和 duplicate/older sequence 都有确定结果。
-
-### R4-C：Conversation extension points
-
-- `conversation.read` 提供 cursor/page-size 有界 normalized entries；不暴露 raw event log。
-- `conversation.navigate` 只改变当前 frontend viewport，不修改 session。
-- `conversation.itemActions` 注册 label/applicability/handler；Blue 在 dispatch 前复查 item ref epoch/revision并提供 gesture/signal，插件调用自己的 domain service。
-
-Rewind、Message Edit 和无 domain mutation 的 Bookmark/Tag reference fixture 必须共用该扩展点，禁止为某一个插件新增业务字段。Peak Indicator 走 additive status，不计作 item-action 泛化证据。
-
-### R4-D：Theme 与 settings
-
-- `theme.provider` 注册 semantic token candidate；用户选择、token validation、fallback、unload/swap 与 status provider 同等级。
-- `settings.sections` 只管理 Blue 设置 UI composition；schema/value/commit/conflict/persistence 由插件直接 inject `dsh-settings`。
-- Catppuccin 不能复制 JSON 到 Blue 包，也不能输出 ANSI；它只注册 theme candidate 和可选 settings section。
-
-### 每项退出门
-
-- 至少两个独立消费者（一个 Blue official/reference、一个独立生态包）、absence fallback、Fiber unload 和 package/bundle composition 齐全。
-- read capability 有 replay/resume/stale；action 有 gesture/abort/stale/double-submit；renderer contribution 有 width/failure isolation；provider 有 swap/LKG/breaker/fallback。
-- packed fixture current/previous Harness line 均执行，无 skipped。
-
-## 7. R5：Editor Experimental
-
-在保留 #77 editor runtime 的基础上，按最小权力拆分：
-
-1. `editor.decorations`：先迁 passive before/after、hint、diagnostic、action。
-2. `editor.completions`：独立 trigger/query、mux、timeout、abort、stale 和 result cap。
-3. `editor.draft.read`：revisioned readonly draft snapshot。
-4. `editor.draft.write`：expected revision 的结构化 insert/replace；与 history/IME transaction一致。
-5. `editor.submit.transform`：固定排序、逐项 timeout、abort、rollback，提交清空前完成 barrier。
-
-全部只能 optional，owner/fixture 缺失不阻止插件加载。Composer History 验证 draft read/write 和 session/editor reload；`@/#` completion 与 submit transformer 各自使用独立 fixture。
-
-Composer History 的 v1 fixture 只验证显式 history command/overlay 与 draft read/write，不承诺原 Web 版的 ArrowUp edge recall 或 Ctrl+R。精确按键体验依赖尚未泛化的 contextual editor-key seam，列入 Deferred 独立设计；不得把 raw key handler 塞进上述五个 capability，也不得因此阻断 `1.0.0`。
-
-#77 已实现的 `editor.provider` owner、persisted user selection、actual-width dry render、同 editor/focus shell swap、LKG/breaker/default fallback 和 stale/unload fencing作为本阶段基础保留，不重新实现。本阶段把它迁入明确的 Experimental schema/catalog/subpath，并冻结为 host-owned editor engine 外层的 shell provider：candidate 必须恰好贡献一个 `editor-control`，不得获得 draft/cursor/history/undo/IME、raw key 或 editing-engine ownership。
-
-它发布为 Experimental 前必须进入 optional schema/catalog/subpath，冻结 activate/dispose 或“纯无状态 shell无需 hook”的 public lifecycle语义，完成 final-head current/previous Harness reference packed fixture，并在统一 profile 通过 draft/history/mode/attachments/focus/IME、failure rollback、session swap 和 unload/reload 的真人验收。固有 snapshot 不再隐式提供 mode；需要 mode 的插件另申请 `session.read` grant。它不进入 Stable catalog、不计作三种 form 的 Stable 外部证据；独立生态 provider和其余 Stable 门禁留给未来另开的 1.x 晋升提案。
-
-## 8. R6：Conformance 与生态 fixture
-
-### Synthetic conformance kit
-
-#77 已提供可复用的 `script/blue-plugin-fixture.mjs`、`script/blue-examples-fixture.mjs`、throwaway packed install、peer closure 和 current/previous Harness lanes。R6 在该基础上扩展或拆出 versioned kit，使每个测试包从 `npm pack` tarball 安装，只 import public exports。报告必须保持：
-
-```text
-declared == executed
-skipped == []
-failures == []
-fixtureCleaned == true
-```
-
-统一的是场景词表和 capability -> required scenarios 映射，不要求无关 fixture 假跑不适用场景。词表包含 manifest negotiation、resource denial、projection replay/resume、action abort/stale、provider swap/fallback、unload/reload、late callback、20/40/80/120 width、bundle composition、当前/上一 Harness exact line；每个 fixture 的全部 declared/applicable 场景必须执行，`skipped` 仍为空。
-
-#77 的六个 executable plugin examples 继续作为 Beta/reference distribution corpus；连同 `blue-user-kit` 和 `blue-ecosystem` composition 是八包 suite。六个 entry 仍是 flat `capabilities[]`，没有 `form`、required/optional/resources negotiation，也不是独立生态 package。R6 必须将其迁到目标 schema，并另用真实外部 package 关闭三种 form 与独立消费者门禁；组件库和 composition bundle都不构成第四种 form。
-
-### 三形态候选与证据等级
-
-下表中的 `form` 指目标发布的 Blue entry，不是某个生态项目的固有属性。审计冻结于 2026-08-28/29；commit 是 fixture 可复现基线，不是要求永远跟随的版本。Fixture MAY 暂存于 Blue conformance 仓或固定 commit fork，但必须记录 upstream commit、补丁、同步/删除条件、发布/代码 ownership 和作者合作状态。同一功能若由上游同包发布就是 `integrated`，由独立 `*-blue` 包只消费其 service 则是 `adapter`；fixture manifest 必须按实际 ownership 选择，不能按本表名称猜测。
-
-| Form | 候选与冻结证据 | 目标 Blue 边界 | 当前可行性 | v1 角色 |
-| --- | --- | --- | --- | --- |
-| pure-ui | [Catppuccin](https://github.com/NoNameLeGo/dsh-catppuccin-theme) `a44df0045d81` | 四套 theme JSON -> `theme.provider`；可选 `settings.sections`，持久化走 `dsh-settings` | 高；现有 TUI 会写 `~/.dsh-tui/themes`，新 Blue entry 必须直接注册 semantic tokens，且不得启动 sibling Web/update route | **首批 POC / Stable blocker** |
-| pure-ui | [Conversation Navigator](https://github.com/gjj-star/dsh-conversation-navigator) `9682972130d8` | `conversation.read`、`conversation.navigate`、`session.read`、`panes`，可选 `commands` / `settings.sections` | 高；当前 browser entry 与空 host shell 已分离，重点是分页、session switch、stale jump、width | 第二波 Stable evidence |
-| pure-ui | [Composer History](https://github.com/PerryLink/dsh-composer-history) `16feb04aaaaf` | Experimental `editor.draft.read/write`、`conversation.read`、`overlays`、`settings.sections` | 中；v1 只迁显式 history/draft 子集，ArrowUp/Ctrl+R 等 contextual key seam Deferred | Experimental，**不阻断 1.0** |
-| adapter | [Cost Meter](https://github.com/Han-1413141/dsh-cost-meter) `56455e17848d` | 独立 Blue adapter 直接 inject 公开 `costMeter` service，并申请 `projections.read` resource `{ keys: ['costUsage'] }`；只向 `status` / `panes` / `commands` / `notifications.publish` / `settings.sections` 投影 | 高；已有公开 service 和 projection，不产生 `cost.*` Blue capability，也不复制费用真相 | **首批 POC / Stable blocker** |
-| adapter | [Turn Rewind](https://github.com/Anionex/dsh-turn-rewind) `d3734cb183a5` | 独立 Blue adapter inject `rewind` service 后消费 `conversation.itemActions`、`overlays` | 阻塞；当前只有 `/rewind` command 和 raw Agent/Session 执行。作者需先抽 `list/preview/execute` renderer-neutral service；若 Blue face 改由上游同包拥有，form 应改为 integrated | 前置条件项；可由 Message Edit + Bookmark/Tag reference 补其 v1 证据 |
-| integrated | [dsh-context](https://github.com/bowenliang123/dsh-context) `6d17588a5672` | 同包 headless projection 与独立 Blue entry；消费 `projections.read` / `status` / `panes` / `overlays` / `commands` / `settings.sections` | 高；先做 headline、composition、recent events，不复制完整 Web dashboard | **首批 POC / Stable blocker** |
-| integrated | [OpenPencil](https://github.com/ZSeven-W/dsh-openpencil) `906ff9c2fcda` | domain/tool 继续 headless；Blue v1 只验证 canonical text/diff fallback、signed-meta elision 和 `notifications.publish` | 当前 `@dsh-blue/blue-openpencil` 是独立 adapter；本行只在上游作者拥有同包 Blue entry 后成立。Rich workbench 依赖 Deferred tool-presentation，不能搬 Web canvas 或 capability bearer | v1 negative/fallback；rich UI 不阻断 1.0 |
-| integrated | [Lark](https://github.com/sugarforever/dsh-lark) `ee639df50fc7` | 上游同包 Blue entry 消费 `commands` / `notifications.publish` / `settings.sections`；domain runtime 独立 | 当前 `@dsh-blue/blue-lark` 是 loopback HTTP compatibility adapter，不是 integrated。上游公开 service/内置 Blue face 后删除 adapter | 未来 integrated，非首批 blocker |
-
-表外另保留两条不同性质的证据：
-
-- [Blue Remote](https://github.com/GeekCmore/dsh-remote) `423c736869aa` 是 transport/protocol infrastructure fixture，验证 negotiate、seq resume、lease、question/approval、reconnect 和 unload。它当前不消费 Stable UI capability，因此不冒充三种 Blue plugin form；待 Deferred session/frontend provider 契约再重新分类。该项目也不能与市场中同名 remote 包混淆。
-- [Modlens](https://github.com/liustack/modlens) `147356e6dde0` 是 zero-Blue-API negative fixture：它继续只通过 Harness tool/provider 工作，Blue 无 manifest、无专用 capability 也能呈现通用结果。该用例防止“为了市场覆盖给每个 domain 发明 capability”。
-
-Conversation item-action 的外部压力基线另冻结为 [Message Edit](https://github.com/Moeblack/dsh-message-edit) `b78a167064ca`，但它与 Rewind 一样要先抽 renderer-neutral service。Bookmark/Tag 是明确标记的 in-repo reference fixture，不伪装成外部生态消费者；创建时记录自身 commit。
-
-[dsh-status-bar](https://github.com/Starlight-bananice/dsh-status-bar) `128a7f3d1256` 是 `status.provider` 的独立生态候选。首个 fixture 严格限定为 minimal pure-ui provider slice，只消费 `session.read` 的 status/cwd/mode/model 和 sanitized additive entries；完整 17 段与费用历史版是后续 integrated 目标，需要 allowlisted `projections.read`，并先把 JSONL/HTTP ledger 抽成 renderer-neutral Cordis service。只有该外部 slice 通过 packed/provider-swap/width 门禁后，才满足 Stable 的外部消费者条件。
-
-[Peak Indicator](https://github.com/future007s/dsh-peak-indicator) `887bbe7040f1` 是 additive `status` 候选，只验证峰谷时段徽标与 timer/unload；它不替代 `status.provider`，也不计作 conversation item-action consumer。
-
-候选池是 discovery/fixture portfolio，不是等权 release blocker。`1.0.0` 的硬门是三种 form 各至少一个 Stable packed fixture、每个 Stable capability 的 owner/consumer/fallback/lifecycle 证据，以及所有声明场景零 skip；Experimental、Deferred 或明确阻塞的候选不因尚未迁移而阻止发布。反过来，首批三个 POC 也不能替代它们没有覆盖的 Stable conversation/provider 证据，或另行声明的 editor Experimental 证据。
-
-### 首批 POC
-
-按实现风险优先完成：
-
-1. Catppuccin：最快证明 pure UI/theme provider；
-2. Cost Meter：证明公开 service/projection 的窄 adapter；
-3. dsh-context：证明 integrated projection 到 TUI。
-
-选择依据来自 dsh-market 2026-08-28 registry snapshot：Catppuccin 为 20 stars / 5,806 downloads，Cost Meter 为 195 / 17,152，dsh-context 为 1,037 / 32,099。三者兼顾可见用户量和低到中等迁移风险，且不会用同一 capability 的三个变体冒充架构覆盖。
-
-三者 packed fixture 通过后再联系作者。每个合作包携带 frozen upstream commit、可安装 tarball、可运行 profile patch、迁移 diff、短终端录屏、machine-readable fixture JSON、fallback 表和建议代码 ownership，而不是只发送合作设想。它们共同作为联系 dsh-market 的 Blue 能力 demo。下载量是快照中的相对优先级信号，不是协议或长期流量承诺。
-
-dsh-market 不作为 v1 阻断 fixture。在审计基线 [`d5902420b175`](https://github.com/dsh-market/dsh-market/commit/d5902420b175) 中，catalog/安装/profile 更新仍主要封在 HTTP routes；Update API v1 仍为 beta，范围只覆盖 check/start/observe/rollback/restart，不足以支撑完整 TUI 市场。Blue 不能调用私有 route、复制 pnpm/profile/restart 逻辑或定义 `market.install` capability。
-
-合作前置是 dsh-market 抽出 typed/versioned renderer-neutral Cordis service/controller，至少覆盖 catalog/search、installed/check、install/update/uninstall/toggle、operation progress/cancel/rollback；同时固定 error taxonomy、policy/authorization 和 lifecycle。Service mutation 接受 AbortSignal、profile scope 和 dsh-market 自己的 authorization context，并由 dsh-market Fiber 持有恢复与 restart 策略；Blue adapter 在调用前消费 Blue user gesture，不能把 Blue token 泄漏进 domain service。Blue 只用 `commands` / `panes` / `overlays` / `notifications.publish` 呈现，成为第一个非 Web consumer。现有 beta Update API 可做受限 update-status pilot，但不能被描述为完整 market 集成。Agent Teams、Browser 等同样作为后续 capability discovery，不阻塞 1.0。
-
-## 9. R7：Skills、创造模式与开发者文档
-
-Skills 在 API 和 fixture 稳定后更新，避免教会开发者一套过期接口。
-
-| Skill | 必须更新的行为 |
-| --- | --- |
-| `plugin-development` | 选择三种 form、生成 package pointer/manifest、区分 direct inject 与 Blue capability、required/optional/resource/fallback |
-| `plugin-migration` | 输出 Domain/Projection/Action/UI/Composition、form、scope、adapter 删除条件；识别 HTTP closure 和不需要 Blue API 的插件 |
-| `plugin-fixture` | 生成 packed current/previous-line 场景；按 capability 自动选择 replay/abort/stale/swap/width/unload；禁止 skipped 充当证据 |
-| `plugin-validation` | schema、public/control plane、package export/files/tsdown、Fiber、bundle/profile/human acceptance 一体门禁 |
-
-每个 skill 至少有 integrated、adapter、pure-ui 和 zero-API 四类 eval；输出引用生成的 capability catalog，不内嵌名字副本。
-
-### 创造模式 authoring pipeline
-
-现有 `cordis` preset、creative isolate 和真实 `cordis_define/run/update/stop/rollback` e2e作为动态原型底座保留。它们当前仍教授 flat manifest、`^1.0.0`、`session.act`、notification observe与旧 identity，而且测试只验证 skill discovery和动态 runner生命周期，没有执行 bundled skills、生成持久包或运行 packed fixture。R7 必须把创造模式升级为 v1 插件开发入口和 official consumer，而不是增加第四种 plugin form。
-
-目标流程为：
+保留现有 inspect、define、run、update、stop、rollback 和隔离 runtime；新增持久包闭环：
 
 ```text
 需求与 zero-API 判断
-  -> inspect + 加载 bundled cordis-plugin-development
-  -> host-minted transient capability request + 动态原型
-  -> 当前会话 UI 验收
-  -> 用户选择 ephemeral / local / GitHub / npm
-  -> 加载 bundled blue-plugin-development
-  -> 生成 v1 package
+  -> inspect + 临时 capability request
+  -> 会话内原型
+  -> 用户验收
+  -> 明确选择 ephemeral / local / GitHub / npm
+  -> 生成 package + blue.plugin.json
   -> shared validator
-  -> current/previous Harness packed fixture
+  -> npm pack
+  -> current/previous Harness 独立安装 fixture
 ```
 
-具体交付要求：
+确认前不得生成持久 package、repository、commit、tag 或 release。v1 的确定性硬门止于本地持久包和双线 fixture；GitHub/npm 真实发布、凭据与 2FA 只在用户明确确认后执行。
 
-1. preset persona、bundled `cordis-plugin-development` / `blue-plugin-development`、仓内四项 plugin skills和中英文文档直接消费发布的 schema、generated capability catalog、TypeScript API与模板；不得复制 capability/version名单。
-2. 动态 `code.host` 使用由同一机器契约生成并经 host校验的 authoring-only transient capability request；creative host分配临时 identity，请求不能伪造 package `entry`、`form` 或 installer receipt。它只能消费获准的 Stable facet和 optional Experimental facet，不能通过 raw Agent/Session、owner registry、`session.act` 或 notification observe延续旧 API。transient prototype不是可发布 entry，也不算一种 form。
-3. 持久化前先判断 zero-API；确需 Blue entry时必须选择 `integrated | adapter | pure-ui`。三种 scaffold分别落实 headless domain/UI scope分离、上游公开 service inject与 adapter删除条件、无 domain dependency，并生成 required/optional/resources、grants检查和逐能力 fallback。
-4. 用户确认前不得写 package、仓库或发布物。确认后生成 `package.json.blue.manifest` pointer、`blue.plugin.json`、public exports/files、Cordis entry和 composition；entry解析同一 JSON，不能保留原型 inline manifest作为第二真相。
-5. 发布一个可在 workspace外直接调用的 versioned scaffold/validator/conformance kit；不能要求插件作者 clone Blue，也不能让 fixture因包不在当前 pnpm workspace而拒绝。生成后自动进入修复循环，直至 validator和双 Harness线 packed fixture均通过且无 skip。
-6. integrated、adapter、pure-ui、zero-API各有 skill eval；negative eval覆盖 HTTP-only业务 closure、raw Agent/Session、被拒绝 capability、Experimental放 required、无 fallback和多余授权。
+### 5.3 两类 skills
 
-创造模式门禁必须检查 schema -> generated TS -> runtime validator -> installer -> capability catalog -> templates -> skills/docs 的生成漂移，以及 API/schema/skill/template version stamp一致。preset、skills和模板中回流 flat `capabilities: []`、generic `session.act`、普通 `notifications.subscribe`、旧 identity/entry示例时 CI直接失败。bundle/authoring-kit tarball必须实际携带并可解析其承诺的 schema、catalog、templates和工具。
+- `blue-ecosystem-outreach` 仅供 Blue 维护者：审计公开边界、生成内部可行性骨架和机器证据、输出邀请 Issue 草案；实际发 Issue 前再次确认；默认不生成上游代码 PR。
+- `blue-plugin-development` 是作者唯一入口：支持新插件和现有 Harness 插件增加同包 Blue frontend entry，生成 manifest/entry/fallback/fixture，遇到缺失 Stable capability时停止并输出提案。
 
-开发者文档最后生成并保持中文源、英文镜像：
+作者 skill 只维护一份，位于 Blue 仓库创造模式 preset；标准模式不加载。邀请 Issue 直接链接 GitHub 中这份 skill。两类 skill都读取发布的 schema/catalog，不复制 capability 名单。
 
-- concepts：三种 form 与四种架构职责；
-- manifest：schema、identity、entry、compatibility、capability negotiation；
-- capabilities：生成的 Stable/Experimental 表、resource/fallback；
-- quickstart：三个最小样例，实际包含 `blue.plugin.json` 并从 tarball 安装；
-- migration：从 flat Beta manifest、dock、notifications、session/editor 旧面迁移；
-- testing：validator、packed fixture、previous Harness、width/profile/human gate；
-- API reference：TS declaration、schema URL、error taxonomy 和版本政策。
+### 5.4 Website 开发手册
 
-所有教程样例本身进入 packed fixture。网站 build、链接、中文/英文结构 parity、catalog drift 和 creative-mode 教程/模板 drift 是 CI gate。
+中文源、英文镜像按任务递进：开始开发、选择接入路径、架构术语、包与 manifest、UI capability、session 数据、生命周期、Web 迁移、创造模式、验证发布、案例、API reference。教程样例自身进入 packed fixture；website build、链接、双语结构和 schema/catalog drift进入 CI。
 
-完成后归档 `blue-api-design.md`、PR #77 的 UI blueprint 和已结束的 frontend-runtime cutover 套件；保留 `blue-frontend-architecture.md` 作为原则、package AGENTS 作为当前实现。归档移动单独提交，统一修复根 AGENTS、`CODEX-IMPLEMENTATION-GUIDE.md` 和 docs links。
+## 6. R4：Stable 晋升
 
-## 10. R8：`1.0.0` 发布门禁
+七项 capability逐项晋升，不以“代码已经存在”代替证据。每项必须具备：
+
+- 真实 owner 与官方/reference consumer；
+- 至少一个真实 Harness 插件 consumer；
+- capability absence/plain fallback；
+- renderer contribution 的 width/failure isolation，read 的 replay/resume/stale，action 的 gesture/abort/stale，按适用场景齐全；
+- 当前/上一 Harness line的独立 packed fixture，`declared == executed`、`skipped == []`、`failures == []`；
+- package/bundle composition、unload/reload、late callback和真实 profile验收；
+- 作者手册、skill、API declaration和机器 catalog一致。
+
+provider、conversation、theme/settings、editor 等不因已有 #77 runtime 自动晋升；它们继续作为内部/reference 或 Experimental 候选，在后续 1.x 以真实消费者共创。
+
+## 7. R5：dsh-market Beta 合作
+
+联系时机：公开 Beta、作者 skill和至少两个可运行生态验证项目就绪后。
+
+v1 合作范围：
+
+- Blue frontend entry metadata；
+- Blue-compatible badge/filter；
+- `blue` profile 安装路径；
+- 与 dsh-market metadata/specification system 对齐；
+- 双方文档互荐与 TUI 定位说明。
+
+dsh-market 当前 Web HTTP routes 和 beta Update API 不被包装成完整市场 Service。Blue 不调用 private route、不复制 pnpm/profile/restart逻辑，也不定义 `market.install` capability。完整 catalog/search/install/update/uninstall/rollback TUI 等 dsh-market 提供 typed、versioned、renderer-neutral Cordis Service 后另行设计。
+
+## 8. R6：`1.0.0` 发布门
 
 按以下顺序关闭：
 
-1. schema、generated TS、runtime/validator/installer corpus green；
-2. Stable capability catalog 每项 owner/consumer/fallback/fixture complete；
-3. API declaration report 确认 root 无 Experimental/Deferred/control-plane 泄漏；
-4. 三种 form 各至少一个 Stable 生态 fixture、Stable catalog 的逐项证据和 Modlens zero-API negative fixture 在 current/previous Harness line green；候选表中 Experimental/Deferred/blocked 项不计作未完成 blocker；
-5. 四类 skills eval、创造模式生成门禁与中英开发者文档 green；
-6. 创造模式 full e2e 使用实际 bundled `cordis` preset和 bundled skills完成 inspect -> transient prototype -> UI可见 -> 用户确认 -> 生成包 -> shared validator -> `npm pack` -> current/previous Harness独立安装 -> boot/render -> unload/reload；确认前无持久化写入，报告满足 `declared == executed`、`skipped == []`、cleanup成功；
-7. 全仓 test、coverage、typecheck、lint、build、check:lib、check:pack、diagrams、website build 和 smoke green；
-8. 独立 `blue-<tag>` profile 覆盖 install、unload/reload、provider/theme/session swap、120/80/40 列、首批 POC和至少一次真人创造模式原型到本地包流程；
-9. 用户 live-test 并明确验收；
-10. 将 API/host version 从 `1.0.0-beta.1` 改为 `1.0.0`，发布 schema stable URL、packages 和 migration notes；
-11. 从 registry 新建干净 profile 做 install smoke，记录 exact artifacts/Harness line。
+1. schema、generated TS、runtime validator、installer、catalog和version mapping green；
+2. 七项 Stable capability逐项证据完整，Stable root无 Experimental/owner power；
+3. 六项目矩阵的适用技术切片都有明确状态，发布证据覆盖七项能力；外部作者响应不作为硬门；
+4. 创造模式完成 prototype -> accept -> local package -> validator -> `npm pack` -> 双 Harness独立安装；
+5. 两类 skill eval和中英文开发手册 green；
+6. full repository gates、website、packed install和真实 profile smoke green；
+7. worktree profile覆盖 install、unload/reload、session swap、120/80/40和生态验证切片；
+8. 用户 live-test并明确验收；
+9. API/host从 `1.0.0-beta.*` 晋升 `1.0.0`，发布 immutable schema/API、mapping和migration notes；
+10. 从 registry新建干净 profile做最终 install smoke并记录 exact artifacts。
 
-任何 skipped fixture、任一已声明 Stable capability缺少真实 owner、只有 Web route的业务 API、创造模式仍生成旧协议或不能完成持久包双线验证、缺失上一 Harness line、缺失人工验收都阻止 `1.0.0`。Blue 产品 release仍可保持 `0.x`，不需要为了协议 v1人为提升产品 major。
+任何 Stable capability缺真实 owner/consumer/fallback、任何适用 fixture skip、private Web route被当公开 API、创造模式不能生成并验证本地持久包、上一 Harness line或人工验收缺失，都阻止 `1.0.0`。Blue 产品版本仍可保持 `0.x`。
 
-## 11. 工作方式
+## 9. 工作方式
 
-- 每个阶段使用独立 worktree 和小 PR；不把所有收敛重新塞回 #77。
-- 每个 capability PR 同时改 code、tests、package AGENTS、bundle row、fixture 和当前实现文档。
-- 目标契约变更必须先通过协议评审；实现进度只更新矩阵/roadmap。
-- 用户可见行为按仓库规则安装到 worktree 专属 profile，真人验收前不合并、不删除 profile。
-- 路线完成后本文归档到 `docs/history/`，由 release notes 和生成 API reference 接替。
+- 每个阶段使用独立 worktree和小 PR；不把 v1 roadmap全部塞回 #77。具体拆分使用合并手册的 P1-P9 队列。
+- capability PR同步修改 code、tests、package AGENTS、bundle composition、fixture和当前实现文档。
+- API 设计变化先评审设计规范；实现进度只更新矩阵/roadmap。
+- Website 正式开发手册、作者 skill 和创造模式持久化只能在对应 Beta schema/catalog/validator 可运行后进入 P5，不能回填 PR #79。
+- 用户可见行为必须走 worktree profile和真人验收，验收前不合并、不删除 profile。
+- 技术 conformance、作者联系状态和市场合作状态使用不同字段，不互相冒充完成。

--- a/docs/blue-plugin-api-v1-roadmap.md
+++ b/docs/blue-plugin-api-v1-roadmap.md
@@ -57,20 +57,25 @@ Fixture 与实现按 capability 同步增加；“fixture 阶段”是关闭跨�
 
 ### 实施
 
-1. 将 #77 rebase/merge 本规范，按最新 head 重跑矩阵。
-2. 保留 canonical UI、builders/compiler、panes/overlays、status/status provider 和 editor extension runtime。
-3. 将 API/host version 改为 `1.0.0-beta.1`，删除“当前已经 Stable 1.0”的 README/website 表述。
+截至审计 head `c9e1600`，#77 已完成可保留的 implementation baseline：canonical UI/compiler、panes/overlays、status/status provider、editor extension/provider、split session facade/app owner、consumer lifetime fencing、legacy dock/frontend renderer 删除、六个 runnable examples 与 user kit，以及 checkpoint 化的 current/previous Harness packed 证据。当前 CI 机械复跑 examples，W6-4 在 final head 手工补跑选定 package fixtures；status/editor provider 与 editor extensions 仍须 final-head 重跑。这些都是后续收敛的 seed，不是 Stable v1 结论。
+
+1. 将 #77 rebase/merge 本规范，按最新 head 重跑矩阵并更新 PR body 的 scope、数字和剩余门禁。
+2. 保留上述成熟 runtime；权限和命名收敛不得退回旧 renderer、dock 或未隔离 session facade。
+3. 将 API/host version 改为 `1.0.0-beta.1`，删除“当前已经 Stable 1.0”的 README/website/release-note 表述。
 4. 从 plugin-facing root 移除 owner attach、aggregate snapshot/observe、gesture mint 和强制 close。
 5. 由 bundle composition 创建 canonical owner authority/lease并传给官方 owners；public sibling 即使访问 Cordis `symbols.original` 也不能获得 authority。
-6. 从 Beta public vocabulary 移除 `session.act` 和 Stable `editor.provider`；`session.read` 在真实 owner 前只作为目标文档项，不伪装可协商。
-7. `editor.extensions` 保留实现但标记 Experimental；记录 runtime passive subset 比静态 `BlueUiNode` 更窄的待修项。
+6. 从 Beta public vocabulary 移除 generic `session.act`，并隐藏或 authority-gate当前可直接 inject 的 raw session/projection reader与 requester；保留 negotiated readonly `session.read` seed但明确其 resource/epoch 尚待 v1 收敛。
+7. 修正 editor extension static/runtime node 集合，并把 provider限定为 host-owned editor engine 外层 shell。R1 的 flat manifest尚不能表达 optional，因此两者先退出 public Beta manifest、仅保留 bundle-internal/reference runtime；R2/R3 negotiated optional plane落地后再以 Experimental 公开，不能只改稳定性标签。
+8. 将 `notifications` 拆为 public publish 与 authority-protected owner observe；普通 consumer 不得订阅全局通知。
 
 ### 退出门
 
 - hostile sibling fixture 无法 self-attach、读取 aggregate、observe 全局通知、mint gesture 或关闭别人的 overlay。
-- #77 已有 unit、compile、packed、width evidence 全绿；editor fixture 再穿过真实 input/completion/submit UI。
-- 专用 worktree profile 完成 default、120/80/40 列、provider/theme/session swap 和 editor extension dogfood。
+- #77 已有 unit、compile、packed、width 和 `smoke:happy` evidence 继续全绿；权限修改后的 final head重跑相关双 Harness 线 fixture。
+- `smoke:pty` 与专用 worktree profile 完成 default、120/80/40 列、pane/overlay、status/editor provider、theme/session swap 和 editor input/completion/submit dogfood。
 - 用户明确 live-test 验收后才合并；合并不等于 API v1 发布。
+
+仓内 examples 只算 Beta/reference packed-distribution 基线：它们仍使用 flat `capabilities[]`、内部文件 `entry`，没有 `form`、required/optional/resources，也不是独立生态消费者，不能提前关闭 R2/R6 或 Stable capability 门禁。
 
 ## 4. R2：JSON Schema 与 manifest toolchain
 
@@ -137,7 +142,7 @@ Experimental editor types从明确的 experimental subpath/namespace 进入，�
 ### 现有 surface 收敛
 
 - `notifications` 拆成 public publish 与 owner-only observe。
-- 所有内置 dock consumer 迁到 bottom pane，物理删除 dock compatibility。
+- #77 已将所有内置 dock consumer 迁到 bottom pane并物理删除 dock runtime/type/aggregate/bridge；本阶段只保留旧 manifest 的可操作迁移诊断和 `rg`/schema drift gate，禁止 compatibility 回流。
 - 删除 `BluePluginDefinition.apply(api: unknown)`、inline legacy manifest 和 public owner aggregate。
 
 ### 退出门
@@ -162,10 +167,10 @@ Experimental editor types从明确的 experimental subpath/namespace 进入，�
 
 ### R4-B：Readonly session/projection
 
-1. 从 `BlueSessionReader` 移除 `request()`，建立纯 readonly `session.read` facet。
-2. snapshot 按 identity/cwd/status/mode/model resource 投影并带 `sessionEpoch/revision`。
+1. 保留 #77 已拆出的 `session.read` readonly facade：public consumer 只有 `current/subscribe`。followup/steer/interrupt dispatcher MAY 继续作为 app owner内部实现，但当前通用 `BlueSessionRequester` Cordis service必须删除或改为 composition authority-gated，普通 sibling不能 inject；它 MUST NOT 重新进入 reader、公开 service或 public capability vocabulary。
+2. snapshot 按 identity/cwd/status/mode/model grant 投影并带显式 `sessionEpoch/revision`；订阅 replay、stale 判断和 action reference都以 epoch为界。
 3. 在 app/harness-adapter 建 `projections.read` allowlist gateway；返回一致 cut、`asOfSeq`、有界 immutable value。
-4. session switch、same-id new epoch、key unload、late callback 和 duplicate/older sequence 都有确定结果。
+4. session switch、same-id new epoch、resource denial、key unload、late callback 和 duplicate/older sequence 都有确定结果。
 
 ### R4-C：Conversation extension points
 
@@ -201,13 +206,15 @@ Rewind、Message Edit 和无 domain mutation 的 Bookmark/Tag reference fixture 
 
 Composer History 的 v1 fixture 只验证显式 history command/overlay 与 draft read/write，不承诺原 Web 版的 ArrowUp edge recall 或 Ctrl+R。精确按键体验依赖尚未泛化的 contextual editor-key seam，列入 Deferred 独立设计；不得把 raw key handler 塞进上述五个 capability，也不得因此阻断 `1.0.0`。
 
-`editor.provider` 不在本阶段实现。它必须另开设计提案，并在第二个真实 provider、完整 capture/restore 和真人 dogfood 后才可考虑进入 1.x。
+#77 已实现的 `editor.provider` owner、persisted user selection、actual-width dry render、同 editor/focus shell swap、LKG/breaker/default fallback 和 stale/unload fencing作为本阶段基础保留，不重新实现。本阶段把它迁入明确的 Experimental schema/catalog/subpath，并冻结为 host-owned editor engine 外层的 shell provider：candidate 必须恰好贡献一个 `editor-control`，不得获得 draft/cursor/history/undo/IME、raw key 或 editing-engine ownership。
+
+它发布为 Experimental 前必须进入 optional schema/catalog/subpath，冻结 activate/dispose 或“纯无状态 shell无需 hook”的 public lifecycle语义，完成 final-head current/previous Harness reference packed fixture，并在统一 profile 通过 draft/history/mode/attachments/focus/IME、failure rollback、session swap 和 unload/reload 的真人验收。固有 snapshot 不再隐式提供 mode；需要 mode 的插件另申请 `session.read` grant。它不进入 Stable catalog、不计作三种 form 的 Stable 外部证据；独立生态 provider和其余 Stable 门禁留给未来另开的 1.x 晋升提案。
 
 ## 8. R6：Conformance 与生态 fixture
 
 ### Synthetic conformance kit
 
-扩展 `script/blue-plugin-fixture.mjs` 或拆出 versioned kit，使每个测试包从 `npm pack` tarball 在 throwaway npm project 安装，只 import public exports。报告必须保持：
+#77 已提供可复用的 `script/blue-plugin-fixture.mjs`、`script/blue-examples-fixture.mjs`、throwaway packed install、peer closure 和 current/previous Harness lanes。R6 在该基础上扩展或拆出 versioned kit，使每个测试包从 `npm pack` tarball 安装，只 import public exports。报告必须保持：
 
 ```text
 declared == executed
@@ -217,6 +224,8 @@ fixtureCleaned == true
 ```
 
 统一的是场景词表和 capability -> required scenarios 映射，不要求无关 fixture 假跑不适用场景。词表包含 manifest negotiation、resource denial、projection replay/resume、action abort/stale、provider swap/fallback、unload/reload、late callback、20/40/80/120 width、bundle composition、当前/上一 Harness exact line；每个 fixture 的全部 declared/applicable 场景必须执行，`skipped` 仍为空。
+
+#77 的六个 executable examples 继续作为 Beta/reference distribution corpus，但它们仍是 flat `capabilities[]`，没有 `form`、required/optional/resources negotiation，也不是独立生态 package。R6 必须将其迁到目标 schema，并另用真实外部 package 关闭三种 form 与独立消费者门禁；仓内 `blue-user-kit` 组件库和 `blue-ecosystem` composition bundle都不构成第四种 form。
 
 ### 三形态候选与证据等级
 
@@ -304,7 +313,7 @@ Skills 在 API 和 fixture 稳定后更新，避免教会开发者一套过期�
 9. 将 API/host version 从 `1.0.0-beta.1` 改为 `1.0.0`，发布 schema stable URL、packages 和 migration notes；
 10. 从 registry 新建干净 profile 做 install smoke，记录 exact artifacts/Harness line。
 
-任何 skipped fixture、未实现 owner、只有 Web route 的业务 API、缺失上一 Harness line、缺失人工验收都阻止 `1.0.0`。Blue 产品 release 仍可保持 `0.x`，不需要为了协议 v1 人为提升产品 major。
+任何 skipped fixture、任一已声明 Stable capability 缺少真实 owner、只有 Web route 的业务 API、缺失上一 Harness line、缺失人工验收都阻止 `1.0.0`。Blue 产品 release 仍可保持 `0.x`，不需要为了协议 v1 人为提升产品 major。
 
 ## 11. 工作方式
 

--- a/docs/blue-plugin-contract-v1.md
+++ b/docs/blue-plugin-contract-v1.md
@@ -48,13 +48,15 @@ Domain、Interaction、Renderer、Composition 是代码职责；`integrated`、`
 
 `form` MUST 写入 manifest 并参与 validator 与 packed fixture，但它本身不授予任何 capability。一个 npm 包只有一个 manifest/form；一个 monorepo MAY 通过多个发布包提供多种 form。若 sibling Web entry 含 domain/runtime 逻辑，pure-ui 判定只看 Blue entry 可达依赖仍不够，fixture 还必须证明该 entry 加载时不启动或依赖这些逻辑。
 
+只有可执行并调用 Blue plugin protocol 的 Cordis entry 才声明 `form`。不调用 host 的 renderer-neutral 组件库，以及只安装/排序其他 entry 的 composition bundle，都不是第四种插件形态，也不声明 `pure-ui` 或任何其他 `form`；前者按普通库发布，后者只遵守 Loader composition 契约。
+
 每个 Cordis entry 继续导出稳定 `name`、可选 `inject` 和 `apply(ctx)`。业务 service 依赖只在 `inject` 和 package peer/dependency 中声明，MUST NOT 在 Blue manifest 中复制第二份服务依赖表。
 
 ## 3. 身份、分发与 manifest
 
 ### 3.1 单一身份链
 
-每个 Blue v1 分发包 MUST 在 `package.json` 中声明：
+每个可执行 Blue v1 plugin entry 的分发包 MUST 在 `package.json` 中声明：
 
 ```json
 {
@@ -86,7 +88,7 @@ JSON Schema Draft 2020-12 是 manifest shape 的唯一机器真相；Schema 加�
   "entry": "./blue",
   "api": "^1.0.0",
   "compatibility": {
-    "blue": ">=0.1.0-rc.10 <1",
+    "blue": ">=0.1.1-rc.1 <0.2.0",
     "harness": ">=0.1.1-rc.2 <0.2.0",
     "node": "^22.19.0 || >=24.0.0"
   },
@@ -208,7 +210,7 @@ Blue MUST NOT 定义 `rewind.apply`、`message.edit` 等业务 action。相同�
 
 ### 6.1 Editor Experimental
 
-PR #77 证明 editor extension runtime 可以拥有 revision fencing、completion abort、submit transform 和 unload cleanup，但一个 `editor.extensions` 同时授予被动绘制、读取、写 draft 和改写提交的权力过宽。v1 将其拆为：
+PR #77 证明 editor extension runtime 可以拥有 revision fencing、completion abort、submit transform 和 unload cleanup。当前 `editor.extensions` 把被动绘制/action、completion 和提交改写合在一个 grant 中，但它并不提供 draft read/write。v1 将现有权力拆开，并只通过另行授权的新 capability 提供 draft read/write：
 
 | Capability | 权力 |
 | --- | --- |
@@ -220,11 +222,22 @@ PR #77 证明 editor extension runtime 可以拥有 revision fencing、completio
 
 以上在 v1 schema 中标为 Experimental，只能 optional。Composer History 是 draft read/write 压力 fixture；`@`/`#` completion 与 submit transformer 分别有独立 fixture，不能由一个“大而全”样例替代。公开 TypeScript 类型和 runtime admission MUST 接受同一 node 集合；PR #77 中 `before/after: BlueUiNode` 比 runtime passive subset 更宽的状态不能带入稳定声明。
 
-### 6.2 Deferred
+### 6.2 Editor Provider Experimental
+
+`editor.provider` 在 v1 中 MAY 作为 Experimental optional capability 存在，但只表示 **host-owned editing engine 外层的 renderer-neutral shell provider**，不是编辑器引擎或 renderer 替换权：
+
+- candidate 安装后保持 inert；只有持久化的用户选择可以激活，priority 和安装顺序不得接管 editor；
+- shell 必须恰好包含一个可见 `editor-control`，由 Blue 注入同一个 editor engine；
+- provider 不读取或拥有 draft、cursor、history、undo、IME、paste、attachment storage、completion pipeline 或 submit transaction；固有 snapshot 只含 editor tree 自己拥有的 bounded busy、attachment metadata 和 extension presentation facts；若要 session mode，插件 MUST 另行申请 `session.read` 的 `mode` resource，不能由 provider snapshot 隐式获得；
+- owner 必须在实际宽度 validation/dry render 后原子替换 shell，并实现 generation fencing、abort、same-session LKG、breaker、session/unload default fallback 和 focus restore；
+- provider Fiber 只拥有自身 callback、cache 和异步任务；candidate 卸载不能留下 input、focus、timer 或 renderer object。
+
+PR #77 已提供 persisted selection、actual-width dry render、atomic shell swap、fallback/fencing 的 reference seed和仓内 packed candidate，因此它不再属于“尚无 owner”的 Deferred 项；但当前 public provider仍只有 `render/onEvent`，没有冻结 activate/dispose 或“纯无状态 shell无需 hook”的生命周期语义，不能声称完整事务已经定型。它只有在 Experimental schema/catalog/subpath 隔离、public lifecycle语义、reference packed lifecycle/双 Harness 线、最终 profile dogfood和人工验收完成后才 MAY 作为 Experimental 发布；在独立生态 provider 等 Stable 门禁完成前，它 MUST NOT 标记 Stable，也不计入 Stable v1 capability 的外部消费者门禁。
+
+### 6.3 Deferred
 
 以下名字不进入 v1 public manifest：
 
-- `editor.provider`：等待 capture -> abort -> dispose -> activate -> restore、第二个真实 provider 和完整 draft/history/mode/attachments/focus/IME fixture。
 - `editor.keys` / contextual key interception：等待按 editor state、cursor edge 和 IME transaction 泛化；不得为 Composer History 单独开放 raw key handler。
 - tool presentation：现阶段由 Blue 官方 renderer 和 Harness tool presenter seam 处理。
 - conversation presentation policy：等待多个独立 renderer consumer。
@@ -262,7 +275,9 @@ capture -> abort -> dispose -> activate -> restore
 
 candidate 在选择前 inert。激活失败保留旧 provider 或回退 default；运行失败触发 generation-scoped breaker。安装顺序、priority 或 provider 自己的请求永远不能改变用户选择。
 
-公共 `bluePluginHost` 只能暴露版本、协商和已授予 API。owner attach、aggregate snapshot、notification observe、gesture mint 和强制 close 等 control-plane 操作 MUST 需要 bundle composition 创建的不可伪造 authority/lease；它们不得从 plugin-facing root 获得。Cordis `symbols.original` 不能成为权限升级路径。
+对 `editor.provider`，上述 capture/restore 由 host 在内部保存并恢复同一个 editor engine、draft/history 和 focus；dispose/activate 只作用于 provider shell 自身资源。插件既不会收到 editor engine lifecycle handle，也不能借 provider swap替换或销毁 engine。
+
+公共 `bluePluginHost` 只能暴露版本、协商和已授予 API。owner attach、aggregate snapshot、notification observe、gesture mint 和强制 close 等 control-plane 操作 MUST 需要 bundle composition 创建的不可伪造 authority/lease；它们不得从 plugin-facing root 获得。承载完整 session/projection/action 真相的 raw owner source也不得作为普通 sibling 可 inject 的 Cordis service；第三方只能取得按 negotiated grant裁剪的 facade。Cordis `symbols.original` 或直接 service inject都不能成为权限升级路径。
 
 ## 9. 错误、限制与 fallback
 

--- a/docs/blue-plugin-contract-v1.md
+++ b/docs/blue-plugin-contract-v1.md
@@ -125,6 +125,8 @@ if (!parsed.ok) return
 const opened = ctx.bluePluginHost.open(ctx, parsed.value)
 ```
 
+上述“导入同一 JSON”规则适用于持久化、可安装的 Blue plugin entry。创造模式中的动态 `code.host` 是 process-local、重启即消失的 authoring prototype，不是第四种 `form`，也不能宣称通过 v1 conformance。它 MAY 使用由同一 schema 与 capability catalog 生成、经同一 capability-request validator 接纳的 authoring-only transient request；creative host 为它分配临时身份，该请求不能声明 package `entry`、`form` 或 installer receipt。这不豁免 capability admission、owner isolation 或 Stable/Experimental 规则。用户确认持久化后，工具链 MUST 选择真实 `form` 和 package identity，生成 `blue.plugin.json`，让 entry 解析该文件并重新执行 package、validator 与 packed fixture 门禁，不能把原型请求复制成第二份 manifest 真相。
+
 ## 4. Capability 协商
 
 目标公共形状：
@@ -327,8 +329,10 @@ Manifest/schema 错误有独立、稳定的 validation code。validator、instal
 7. 从 `npm pack` tarball 在独立临时项目安装、只走 public exports 的 fixture；
 8. 当前和上一受支持 Harness exact line 的一致结果；
 9. package exports/files/tsdown、bundle composition、真实 profile 和人工验收证据；
-10. 中英文开发者文档、迁移说明和已更新的开发/迁移/fixture/validation skills。
+10. 中英文开发者文档、迁移说明、已更新的开发/迁移/fixture/validation skills，以及能用同一机器契约产出并验证 v1 插件的 Blue 创造模式。
 
 Fixture 报告的 `declared` 与 `executed` 必须完全相等，`skipped` 和 `failures` 必须为空。自动门禁不能替代需要真人判断的 profile 验收。
+
+创造模式是 schema、catalog、public API、scaffold、validator 与 conformance kit 的官方端到端消费者。它的发布证据 MUST 穿过“transient prototype -> 用户确认 -> 持久化 package -> shared validator -> current/previous Harness packed install”；persona、skills 或模板不得维护独立的 capability/version 名单，也不得通过 raw owner service 让旧接口继续存活。
 
 本文是长期协议真相；实现进度不写在这里。PR #77 的差异和 owner 状态由收敛矩阵维护，交付顺序由 v1 roadmap 维护。

--- a/docs/blue-plugin-contract-v1.md
+++ b/docs/blue-plugin-contract-v1.md
@@ -1,66 +1,55 @@
-# Blue 插件协议 v1 目标态契约
+# Blue 插件 API v1 设计规范
 
-> 状态：**Draft / Target State**
-> 协议版本：`BLUE_API_VERSION 1.0.0`
-> 适用对象：Blue 插件作者、Blue capability owner、安装器、验证器和插件市场
-> 重要：本文描述 v1 发布时必须成立的目标态，不表示 `master` 或 PR #77 已全部实现。
+> 状态：**Draft / Design Source**
+> 协议目标：`BLUE_API_VERSION 1.0.0`
+> 读者：Blue API、host、validator、installer 与文档维护者
+> 插件作者入口：website 的「开发手册」；本文不是入门教程，也不表示当前发布线已实现全部目标。
 
-本文使用 MUST、MUST NOT、SHOULD、SHOULD NOT、MAY 表示规范强度。Blue 产品可以继续使用 `0.x` prerelease 版本；插件协议 `1.0.0` 是独立的兼容承诺。
+本文使用 MUST、MUST NOT、SHOULD、SHOULD NOT、MAY 表示规范强度。Blue 产品包可以继续使用 lockstep `0.x` 版本；插件协议 v1 是独立的兼容承诺。
 
-## 1. 目标与边界
+## 1. 术语与职责
 
-Blue 插件协议只管理 **Blue 自己拥有的前端权力，以及 Blue 对当前绑定 session 的受限 mediation gateway**。后者只裁剪公开 Harness snapshot/projection，不取得 domain authority。Capability 不是插件功能分类，也不是对 Harness API 的通用代理。
+面向插件作者的术语跟随 DeepSeek Harness：
+
+- **Harness plugin**：普通 Cordis 插件，导出稳定 `name`、可选 `inject` 和 `apply(ctx)`。
+- **Host half / Host plugin**：拥有领域状态、Service Definition、projection、action、tool 或 Harness command 的宿主端插件。
+- **Service Definition / Service Provider / 消费方**：Harness 的公开服务约定、实现方和使用方。
+- **session projection**：从 session 事实重放得到的当前只读状态。
+- **Blue frontend entry**：同一分发包中负责 Blue 呈现与交互的 Cordis entry。
+- **composition bundle / profile**：安装、排序和启停插件 entry 的组合单位与运行配置。
+
+Domain、Interaction、Renderer、Composition 是架构职责，不是 manifest 字段。`integrated`、`adapter`、`pure-ui` 只可在迁移指南中用于解释代码组织，不得成为运行时 `form` 或市场等级。
+
+API 实现内部仍可使用 owner、admission、grant、generation 等术语；其权限与重载规则由 [Blue Plugin Host 生命周期规范](./blue-plugin-host-lifecycle.md) 定义，不进入插件作者的基础词汇表。
+
+## 2. 协议边界
+
+Blue 插件 API 只管理 Blue 自己拥有的前端能力，以及对当前绑定 session 的受限只读网关。它不是 Harness API 的通用代理。
 
 ```text
-公开 Cordis service       -> 插件直接 inject
-Harness projection        -> 受资源约束的 projections.read
-Host command/tool         -> 优先使用 Harness 自己的 registry
-仅存在于 HTTP/app 闭包    -> 上游先抽 renderer-neutral service
-Blue 前端自身权力         -> Blue capability
+公开 Cordis Service        -> 插件直接 inject
+Harness session projection -> session.projections.read
+Harness command/tool       -> 优先使用 Harness 自己的 registry
+只有 Web 私有 HTTP route    -> 先抽 renderer-neutral Service Definition
+Blue 前端呈现与交互          -> Blue capability
 ```
 
 因此：
 
-- `cost.*`、`browser.*`、`rewind.*`、`market.*` 属于各 domain 插件，不是 Blue capability。
+- 费用、团队、市场、回滚等业务能力属于各自 Host plugin，不成为 `cost.*`、`team.*`、`market.*` 等 Blue capability。
 - 不提供 generic `host.invoke`、raw Agent/Session/SessionEvent 或通用 `session.act`。
-- 插件配置和持久化直接使用公开的 `@deepseek-ai/dsh-settings` service；Blue 不再包装一套 storage 真相。
+- UI 不得自行折叠 Harness session event，也不得保存第二套领域真相。
 - Blue API 不暴露 pi-tui、ANSI、raw terminal、DOM/React、terminal width、focus handle 或 renderer object。
-- Capability admission 是架构和最小权限边界，不是恶意代码沙箱。第三方 npm/GitHub 代码仍由用户决定是否信任。
+- 插件配置与持久化直接使用公开 Harness Service；Blue 不包装第二套 storage。
+- capability admission 是架构和最小权限边界，不是恶意同进程代码的安全沙箱。
 
-一个新 capability 只有同时满足以下条件，才 MAY 进入 Stable：
+## 3. 分发与发现
 
-1. 至少有两个独立消费者，其中至少一个是 Blue 官方/reference consumer，至少一个来自独立生态包；
-2. 现有公开 Cordis/Harness service、projection、command 或 tool 无法表达；
-3. authority 确实由 Blue frontend tree、当前 session binding 或 renderer 持有；若数据源属于 Harness，Blue 只提供受资源约束的当前绑定/projection adapter，不取得 domain authority；
-4. API renderer-neutral、按最小权限和资源授权；
-5. owner 缺失或 contribution 失败时存在可用 fallback；
-6. 有 official consumer、独立 packed fixture、unload/late-result、abort/stale、provider swap 或 width 证据（按能力适用）。
-
-## 2. 架构角色与三种分发形态
-
-Domain、Interaction、Renderer、Composition 是代码职责；`integrated`、`adapter`、`pure-ui` 是 manifest 所声明 Blue entry 的集成形态。两组概念 MUST NOT 混为一谈。`form` 不给同仓的 Web、daemon 或其他 sibling entry 分类，只约束该 Blue entry 的依赖闭包和运行时行为。
-
-| `form` | Blue entry 拥有或消费的内容 | 必须证明 | 禁止事项 |
-| --- | --- | --- | --- |
-| `integrated` | 同一分发包内的 headless domain 能力和 Blue interaction entry | Blue 不存在时 domain 仍可加载；domain 与 UI 有独立 scope/Fiber；UI 只消费公开 service/projection | domain import Blue；UI 成为业务真相；headless 因缺 renderer pending |
-| `adapter` | 对另一个插件公开 service/projection/action 的 Blue 适配 | `inject` 明确上游服务；adapter 无第二套业务状态；记录上游原生前端契约可用后的删除条件 | 穿透 Agent/Session；import 上游 internal；把 HTTP route 当 API |
-| `pure-ui` | 仅由 Blue 前端拥有的主题、导航、编辑辅助或静态 UI | 无 Harness domain 对象；缺 capability 时 inert/plain fallback；运行态限定在 frontend tree/provider Fiber，UI preference/history 只能经直接注入的公开持久化 service 保存 | 自建 domain 真相；依赖 renderer internal；绕过 host validation |
-
-`form` MUST 写入 manifest 并参与 validator 与 packed fixture，但它本身不授予任何 capability。一个 npm 包只有一个 manifest/form；一个 monorepo MAY 通过多个发布包提供多种 form。若 sibling Web entry 含 domain/runtime 逻辑，pure-ui 判定只看 Blue entry 可达依赖仍不够，fixture 还必须证明该 entry 加载时不启动或依赖这些逻辑。
-
-只有可执行并调用 Blue plugin protocol 的 Cordis entry 才声明 `form`。不调用 host 的 renderer-neutral 组件库，以及只安装/排序其他 entry 的 composition bundle，都不是第四种插件形态，也不声明 `pure-ui` 或任何其他 `form`；前者按普通库发布，后者只遵守 Loader composition 契约。
-
-每个 Cordis entry 继续导出稳定 `name`、可选 `inject` 和 `apply(ctx)`。业务 service 依赖只在 `inject` 和 package peer/dependency 中声明，MUST NOT 在 Blue manifest 中复制第二份服务依赖表。
-
-## 3. 身份、分发与 manifest
-
-### 3.1 单一身份链
-
-每个可执行 Blue v1 plugin entry 的分发包 MUST 在 `package.json` 中声明：
+每个可安装的 Blue frontend entry 所在包 MUST 在 `package.json` 中声明唯一发现入口：
 
 ```json
 {
-  "name": "@scope/example-blue",
+  "name": "@scope/example-plugin",
   "blue": {
     "manifest": "./blue.plugin.json"
   }
@@ -69,37 +58,34 @@ Domain、Interaction、Renderer、Composition 是代码职责；`integrated`、`
 
 规则如下：
 
-- 一个包只有一个 v1 manifest；`blue.manifest` 是发现入口。
-- manifest `id` MUST 等于 npm `package.json.name`，用于安装去重、授权 namespace 和诊断。
-- manifest `entry` MUST 是该包 `exports` 中的公开 subpath（如 `.` 或 `./blue`），不能是 `lib/index.js` 等内部文件路径。
-- Cordis entry 导出的 `name` 是运行时插件名，profile patch row `id` 是 composition-local 名称；二者与 package id 是独立命名空间，不要求相等。
-- validator MUST 验证 manifest、exports、`files` tarball whitelist 和实际 packed tarball 闭包一致。
-- tarball integrity、来源 commit 和安装时间属于 installer lock/receipt，MUST NOT 由包作者写入 `blue.plugin.json`。
+- 一个包只有一个 v1 manifest，且只支持上述发现方式。
+- manifest `id` MUST 等于 `package.json.name`。
+- manifest `entry` MUST 是该包 `exports` 中的公开 subpath，例如 `.` 或 `./blue`。
+- Cordis entry `name`、profile patch row `id` 和 npm package name 是不同命名空间。
+- validator MUST 检查 manifest、exports、`files` whitelist 与实际 `npm pack` tarball 一致。
+- installer receipt、tarball integrity 和来源 commit 由安装器记录，不写进作者 manifest。
 
-### 3.2 v1 manifest 形状
-
-JSON Schema Draft 2020-12 是 manifest shape 的唯一机器真相；Schema 加版本化 semantic validator 构成完整机器契约。Semantic validator 只补跨字段、package/exports 和 semver 规则，不能重新定义 shape。下列 compatibility range 只演示字段和合法 semver，不替代发布时的受支持版本矩阵：
+JSON Schema Draft 2020-12 是 manifest shape 的唯一机器真相；共享 semantic validator 负责跨字段、package、exports 和 semver 规则。目标形状为：
 
 ```json
 {
-  "$schema": "https://dsh-blue.github.io/blue/schema/blue.plugin.v1.schema.json",
+  "$schema": "https://dsh-blue.dev/schema/blue.plugin.v1.schema.json",
   "schemaVersion": 1,
-  "id": "@scope/example-blue",
+  "id": "@scope/example-plugin",
   "entry": "./blue",
   "api": "^1.0.0",
   "compatibility": {
-    "blue": ">=0.1.1-rc.1 <0.2.0",
+    "blue": ">=0.1.0 <0.2.0",
     "harness": ">=0.1.1-rc.2 <0.2.0",
     "node": "^22.19.0 || >=24.0.0"
   },
-  "form": "adapter",
   "capabilities": {
     "required": [
-      { "name": "panes", "version": "^1.0.0" }
+      { "name": "status", "version": "^1.0.0" }
     ],
     "optional": [
       {
-        "name": "projections.read",
+        "name": "session.projections.read",
         "version": "^1.0.0",
         "resources": { "keys": ["costUsage"] }
       }
@@ -108,231 +94,86 @@ JSON Schema Draft 2020-12 是 manifest shape 的唯一机器真相；Schema 加�
 }
 ```
 
-规范要求：
+`schemaVersion`、`id`、`entry`、`api`、`compatibility` 和 `capabilities` 全部 required。未知字段必须被拒绝；同一 capability 在 required/optional 内和跨组均唯一；resource 使用按 capability 判别的 schema。Experimental capability 只能出现在 optional。
 
-- `schemaVersion`、`id`、`entry`、`api`、`compatibility`、`form`、`capabilities` 全部 required。
-- Schema 对未知字段使用 `additionalProperties: false`；扩展通过 schema/API 版本演进，不靠静默接受拼写错误。
-- `api`、compatibility range 和 capability `version` MUST 由真实 semver 实现验证，不能只用正则近似。
-- 同一 capability name 在 required、optional 两组内及跨组均 MUST 唯一。跨数组唯一性由共享 semantic validator 检查，不能假定标准 JSON Schema 能单独表达。
-- `resources` 使用按 capability 判别的 schema；不接受任意对象。
-- Experimental capability 只能出现在 `optional`，插件 MUST 在其缺失时继续加载。
+持久化 entry MUST 导入并解析发布包中的同一份 `blue.plugin.json`，不能在 `open()` 旁手写第二份 manifest。创造模式的动态原型使用由同一 catalog 校验的临时 request；它没有 package identity、entry 或发布一致性声明，不能冒充 v1 conformance。
 
-插件入口 MUST 导入并解析发布的同一份 `blue.plugin.json`，再交给 host；禁止在 `open()` 旁手写第二份 manifest。目标入口流程为：
+## 4. 协商与授权
 
 ```ts
-const parsed = parseBluePluginManifest(rawManifest)
-if (!parsed.ok) return
-const opened = ctx.bluePluginHost.open(ctx, parsed.value)
-```
+interface BluePluginHost {
+  readonly version: string
+  open(owner: BlueEffectOwner, manifest: BluePluginManifest): BlueResult<BluePluginOpen>
+}
 
-上述“导入同一 JSON”规则适用于持久化、可安装的 Blue plugin entry。创造模式中的动态 `code.host` 是 process-local、重启即消失的 authoring prototype，不是第四种 `form`，也不能宣称通过 v1 conformance。它 MAY 使用由同一 schema 与 capability catalog 生成、经同一 capability-request validator 接纳的 authoring-only transient request；creative host 为它分配临时身份，该请求不能声明 package `entry`、`form` 或 installer receipt。这不豁免 capability admission、owner isolation 或 Stable/Experimental 规则。用户确认持久化后，工具链 MUST 选择真实 `form` 和 package identity，生成 `blue.plugin.json`，让 entry 解析该文件并重新执行 package、validator 与 packed fixture 门禁，不能把原型请求复制成第二份 manifest 真相。
-
-## 4. Capability 协商
-
-目标公共形状：
-
-```ts
 interface BluePluginOpen {
   readonly api: BluePluginApi
   readonly grants: readonly BlueCapabilityGrant[]
   readonly unavailableOptional: readonly BlueCapabilityUnavailable[]
 }
-
-interface BluePluginHost {
-  readonly version: string
-  open(consumer: BlueEffectOwner, manifest: BluePluginManifest): BlueResult<BluePluginOpen>
-}
 ```
 
 协商 MUST 遵循：
 
-1. required capability、版本或所声明资源有任意一项不能满足，`open()` 整体失败且不留下 registration。
-2. optional capability 缺失、被 policy 拒绝或版本不兼容，不阻塞插件；原因进入 `unavailableOptional`，对应 API facet 不存在。
-3. required 项的资源是 all-or-nothing；optional 项 MAY 获得请求集合的子集，插件以 `grants` 为准。
-4. host 返回的 limits/quotas 是 grant 的一部分，不由插件自行宣称。
-5. API object 只包含实际获准 facet。注册之后 owner 临时替换时，host MUST 按该 capability 的 retained/fallback 规则处理，并在每次写入时复查 owner generation。
-6. capability version 独立于 Blue 产品版本；host 返回实际选择的精确版本。
-7. 同一 plugin Fiber 重复 `open()`、重复 contribution id、越权资源和 stale write 必须返回结构化错误。
+1. required capability 不受当前 build 支持、版本不相交、被 policy 拒绝或 resource 不能完整授权时，`open()` 原子失败且不留下注册。
+2. optional capability 缺失或只获部分 resource 时不阻止插件加载；插件以 `grants` 和 `unavailableOptional` 为准。
+3. host 返回实际选中的精确 capability version、resources、limits 与 quotas。
+4. API object 只包含获准 facet；重复 open、重复 contribution id、越权 resource 和 stale write 返回结构化错误。
+5. grant 在消费方 Fiber 生命周期内有效；owner 短暂重载不重新解释为“不支持”。可观察规则见第 6 节。
 
-`BlueEffectOwner` 表示调用 entry 当前 Cordis Context/Fiber 的 effect ownership，不是普通插件可构造的权限 token。`open()` 成功后，host MUST 把该 Fiber 的 dispose 级联到所有注册、订阅和 in-flight action；插件 MAY 提前关闭自己的 handle，但不能关闭其他插件或 owner。
+## 5. Stable v1 capability catalog
 
-## 5. Stable v1 Capability Catalog
+v1 只冻结七项能力：
 
-下表是 **v1 发布目标**；当前实现状态见 [PR #77 收敛矩阵](./blue-pr77-convergence-matrix.md)。
+| Capability | 用途 | 资源与边界 | 缺失/失败行为 |
+| --- | --- | --- | --- |
+| `commands` | 注册 Blue-local、带结构化结果的命令 | 名称、数量、并发和 user gesture 受 grant 限制 | 隐藏入口或使用插件自己的 Harness command |
+| `status` | 注册紧凑、非交互状态节点 | frontend tree scope；不能接管整个 footer | 只隐藏失败 contribution，默认状态保留 |
+| `panes` | 注册 header/left/right/bottom managed pane | placement、数量、尺寸受 grant 限制 | 按声明降级或隐藏，不破坏主界面 |
+| `overlays` | 在有效 user gesture 中打开 managed overlay | capturing 数量、focus 与 timeout 由 host 管理 | 返回原 surface，不劫持 focus |
+| `notifications.publish` | 发布有界、可去重的 transient notice | 只有 publish；没有全局 observe | sink 缺失时返回未呈现，不建立队列 |
+| `session.read` | 读取当前绑定 session 的裁剪 snapshot | 只允许获准的 identity/cwd/status/mode/model 字段 | 无 session 返回 `null`；owner 不可用返回结构化错误 |
+| `session.projections.read` | 读取/订阅获准的 Harness projection key | 精确 key allowlist、一致 cut、size bound、epoch/seq | key 或 owner 不可用时返回结构化错误，不复用旧值 |
 
-| Capability | Authority owner / scope | 插件获得的 API | Resource / fallback | 候选证据 |
-| --- | --- | --- | --- | --- |
-| `commands` | interaction owner / frontend tree | 注册 Blue-local command，带 AbortSignal 和 user gesture | 名称、数量与执行并发受 grant 限制；缺失时插件直接使用自己的 domain command 或隐藏入口 | Lark、dsh-context |
-| `status` | status composition / frontend tree | 注册紧凑、非交互 `BlueStatusNode` | contribution 失败只隐藏自身；默认 status 永远保留 | Cost Meter、Peak Indicator、dsh-context |
-| `panes` | surface manager / frontend tree | 注册 header/left/right/bottom managed pane | placement、数量、尺寸由 grant 限制；窄屏按声明降级或隐藏 | Cost Meter、dsh-context、Conversation Navigator |
-| `overlays` | overlay manager / frontend tree | 在有效 user gesture 中打开 managed overlay | capturing overlay 数量受限；失败回到原 surface，不劫持 focus | Rewind、dsh-context |
-| `notifications.publish` | notification model / frontend tree | 发布有界、可去重 transient notice | 不包含全局 observe；sink 缺失时丢弃并返回 availability | Lark、OpenPencil |
-| `status.provider` | status provider composition / provider Fiber | 注册 inert provider candidate | 安装/priority 不自动激活；用户选择、dry render、LKG、breaker、default fallback | official default、dsh-status-bar minimal provider slice |
-| `session.read` | Blue app mediation gateway / current session | readonly current snapshot 与 subscription | `fields` 只允许 `identity/cwd/status/mode/model`；无会话返回 `null`；不得含写方法 | dsh-context、Conversation Navigator |
-| `projections.read` | Blue allowlisted gateway over Harness adapter / session | 从一致 cut 读取并订阅已授权 projection key | `keys` 必须精确 allowlist；值有大小上限；owner 缺失时该 key unavailable | dsh-context、Cost Meter |
-| `conversation.read` | conversation model owner / session | 有界分页读取 normalized entries 和 revision | 当前 session、cursor、page size 和内容类别受限；不返回 raw event log | Conversation Navigator、Rewind（service 前置） |
-| `conversation.navigate` | transcript/navigation owner / frontend tree | 按稳定 item ref 定位当前 conversation viewport | navigation 不修改 session；目标已淘汰时返回 stale | Conversation Navigator、Message Edit fixture |
-| `conversation.itemActions` | conversation interaction owner / frontend tree | 为 item 贡献适用性、label 和 user-triggered handler | ref 含 `sessionEpoch/itemId/revision`；Blue 只调度，业务执行调用插件自己的 service | Rewind（service 前置）、Message Edit（service 前置）、Bookmark/Tag reference fixture |
-| `theme.provider` | theme composition / provider Fiber | 注册 renderer-neutral semantic token candidate | 用户选择、token 完整性检查、default fallback；插件不能输出 ANSI/CSS | Catppuccin |
-| `settings.sections` | settings UI owner / frontend tree | 向 Blue 设置界面贡献 section/form/action | 只拥有呈现；schema、读写与持久化仍由插件注入的 `dsh-settings` service 负责 | Catppuccin、Lark |
+`commands` 只用于需要 Blue UI result/gesture 的入口；能由 Harness command registry 完整表达的领域命令 SHOULD 直接注册到 Harness。
 
-`commands` 只适用于需要 Blue UI result/gesture 语义的本地入口。能够由 Harness command registry 完整表达的 domain command SHOULD 直接注册到 Harness，避免双重发现源。
+`session.read` 和 `session.projections.read` 只返回 readonly、可 clone/freeze 的值，不返回 Agent、Session、Promise、callback 或写方法。projection 的 schema 和业务含义仍由注册该 projection 的 Host plugin 所有。
 
-### 5.1 Session 与 projection 资源
+以下能力不进入 Stable v1 root：provider、conversation extension、theme/settings、editor extension/provider、tool presentation 和 market operation。它们可以在后续 1.x 经过真实消费者共创后，以 Beta/Experimental subpath 提案；不得为了单一插件提前塞进 Stable catalog。
 
-`session.read` 的字段组含义固定如下：
+## 6. 生命周期与可观察行为
 
-| Field group | 允许数据 |
-| --- | --- |
-| `identity` | opaque session id、`sessionEpoch`、snapshot `revision` |
-| `cwd` | 当前工作目录；没有申请时 provider 不应通过其他 Blue snapshot 获得 |
-| `status` | idle/running/waiting/failed 等 renderer-neutral 状态 |
-| `mode` | normal/plan/yolo 的只读有效值 |
-| `model` | provider/model/effort 的只读显示事实 |
+- 所有注册、订阅、timer 和 in-flight work 绑定消费方 Cordis Fiber；unload 后必须撤销并拒绝 late result。
+- `commands`、`status`、`panes` 的最新注册可在官方 UI owner 短暂重载期间保留，恢复后重新挂载。
+- overlay、notification、user gesture、action 和旧 callback result 不排队、不重放。
+- `session.read` 与 projection subscription 恢复时先取得当前 epoch 的一致 snapshot，再恢复 live update；旧 session/epoch 值不得冒充当前状态。
+- contribution failure 只隔离自身；不得扩大 grant、切换到 owner-only service 或让 Agent loop 失败。
+- public API 只描述这些可观察结果；authority、generation 和内部 attach 机制由 host 生命周期规范约束。
 
-`status.provider` 固有 snapshot 只含 status composition 自己拥有的 busy、additive entries、viewport/theme facts。provider 若要 session id、cwd、mode 或 model，MUST 另行申请相应 `session.read` resource；不存在隐藏授权。
+## 7. 版本与兼容性
 
-`projections.read` 每次读取 MUST 返回 `sessionEpoch`、一致 cut 的 `asOfSeq` 和 immutable value。key unload、session switch、duplicate/older sequence 和 late callback MUST 被区分；generic reader 不允许任意字符串越过 manifest allowlist。
+- Blue 产品包继续 lockstep `0.x`；插件协议独立使用 semver。
+- schema、TypeScript API、runtime validator、capability catalog、模板、skills 和 website reference 共享同一 protocol version stamp。
+- 发布不可变 schema/API subpath，并提供机器可读的 Blue product version -> protocol version 映射。
+- 当前 Harness line 与上一条受支持 line 都必须通过 packed-install fixture；支持范围以映射和实际 fixture 为准，不以宽泛 range 推测。
+- Stable API 的破坏性变更需要协议 major；新增 optional capability 或 resource 可走兼容的 1.x 演进。
 
-### 5.2 Conversation item action
+基础错误分类至少包含：API 不兼容、capability 不支持、policy/resource 拒绝、重复 identity、当前不可用、stale/aborted、限额、timeout 和内部隔离。错误必须是 `BlueResult`，包含稳定 code 和可操作 message；插件不得解析 message 取代 code。
 
-`conversation.itemActions` 是扩展点，不是 Rewind 特化：
+## 8. Stable 晋升与发布门
 
-```text
-Blue 提供 item ref + 当前 revision + user gesture + AbortSignal
-插件判断 isApplicable
-用户选择 action
-Blue 复查 epoch/revision 后调度
-插件调用自己 inject 的 domain service
-```
+一项 capability 只有同时满足以下条件才可标 Stable：
 
-Blue MUST NOT 定义 `rewind.apply`、`message.edit` 等业务 action。相同扩展点由 Rewind、Message Edit 和无 domain mutation 的 Bookmark/Tag reference fixture 共同验证泛化性；Peak Indicator 属 additive status，不能拿来充当 item action 证据。
+1. Blue 有真实 owner 和官方/reference consumer；
+2. 至少一个真实 Harness 插件通过公开 API 消费该能力；作者是否已经合并上游不改变技术证据；
+3. 现有公开 Harness Service、projection、command 或 tool 无法完整替代该能力；
+4. 有 capability-absent/plain fallback；
+5. 独立 `npm pack` fixture 在当前/上一 Harness line 执行全部适用场景；
+6. unload/reload、late result、abort/stale、width 或 replay/resume 证据按能力齐全；
+7. website 开发手册、作者 skill 和 API reference 与机器 catalog 一致。
 
-## 6. Experimental 与 Deferred
+Conformance 报告必须记录 source commit、tarball digest、Blue product/protocol/Harness versions、declared/granted capabilities、declared/executed/skipped/failures、fallback、unload、width 和 cleanup。硬门为 `declared == executed`、`skipped == []`、`failures == []`、cleanup 成功。作者联系与认可状态单独记录，不混入 conformance 结论。
 
-### 6.1 Editor Experimental
+## 9. 作者文档边界
 
-PR #77 证明 editor extension runtime 可以拥有 revision fencing、completion abort、submit transform 和 unload cleanup。当前 `editor.extensions` 把被动绘制/action、completion 和提交改写合在一个 grant 中，但它并不提供 draft read/write。v1 将现有权力拆开，并只通过另行授权的新 capability 提供 draft read/write：
-
-| Capability | 权力 |
-| --- | --- |
-| `editor.decorations` | hint、diagnostic、before/after passive node 和结构化 action |
-| `editor.completions` | 接收有界 query/trigger，异步返回 completion；必须支持 abort/stale |
-| `editor.draft.read` | 读取当前 draft 的 readonly、revisioned snapshot |
-| `editor.draft.write` | 以 expected revision 提交 replace/insert 等结构化变更 |
-| `editor.submit.transform` | 在有界流水线中转换提交值；顺序、timeout、abort 和 rollback 明确 |
-
-以上在 v1 schema 中标为 Experimental，只能 optional。Composer History 是 draft read/write 压力 fixture；`@`/`#` completion 与 submit transformer 分别有独立 fixture，不能由一个“大而全”样例替代。公开 TypeScript 类型和 runtime admission MUST 接受同一 node 集合；PR #77 中 `before/after: BlueUiNode` 比 runtime passive subset 更宽的状态不能带入稳定声明。
-
-### 6.2 Editor Provider Experimental
-
-`editor.provider` 在 v1 中 MAY 作为 Experimental optional capability 存在，但只表示 **host-owned editing engine 外层的 renderer-neutral shell provider**，不是编辑器引擎或 renderer 替换权：
-
-- candidate 安装后保持 inert；只有持久化的用户选择可以激活，priority 和安装顺序不得接管 editor；
-- shell 必须恰好包含一个可见 `editor-control`，由 Blue 注入同一个 editor engine；
-- provider 不读取或拥有 draft、cursor、history、undo、IME、paste、attachment storage、completion pipeline 或 submit transaction；固有 snapshot 只含 editor tree 自己拥有的 bounded busy、attachment metadata 和 extension presentation facts；若要 session mode，插件 MUST 另行申请 `session.read` 的 `mode` resource，不能由 provider snapshot 隐式获得；
-- owner 必须在实际宽度 validation/dry render 后原子替换 shell，并实现 generation fencing、abort、same-session LKG、breaker、session/unload default fallback 和 focus restore；
-- provider Fiber 只拥有自身 callback、cache 和异步任务；candidate 卸载不能留下 input、focus、timer 或 renderer object。
-
-PR #77 已提供 persisted selection、actual-width dry render、atomic shell swap、fallback/fencing 的 reference seed和仓内 packed candidate，因此它不再属于“尚无 owner”的 Deferred 项；但当前 public provider仍只有 `render/onEvent`，没有冻结 activate/dispose 或“纯无状态 shell无需 hook”的生命周期语义，不能声称完整事务已经定型。它只有在 Experimental schema/catalog/subpath 隔离、public lifecycle语义、reference packed lifecycle/双 Harness 线、最终 profile dogfood和人工验收完成后才 MAY 作为 Experimental 发布；在独立生态 provider 等 Stable 门禁完成前，它 MUST NOT 标记 Stable，也不计入 Stable v1 capability 的外部消费者门禁。
-
-### 6.3 Deferred
-
-以下名字不进入 v1 public manifest：
-
-- `editor.keys` / contextual key interception：等待按 editor state、cursor edge 和 IME transaction 泛化；不得为 Composer History 单独开放 raw key handler。
-- tool presentation：现阶段由 Blue 官方 renderer 和 Harness tool presenter seam 处理。
-- conversation presentation policy：等待多个独立 renderer consumer。
-- full frontend/composition provider：只允许受信 bundle composition，不能伪装成普通动态插件 capability。
-
-以下名字被明确拒绝：`session.act`、`notifications.observe`（仅 owner/internal）、`storage`、`renderer.provider`、`host.invoke` 和任何 domain-specific capability。
-
-## 7. 数据、action 与 renderer-neutral 约束
-
-- 事件表示已发生事实，projection 表示当前状态，action 表示有结果的写请求。
-- 公共 snapshot/model MUST readonly、有限、有 scope，并且不能包含 Promise。异步只存在于 action/provider callback 边界。
-- UI node 是 renderer-neutral 的结构化数据。注册在同一进程内的 callback 和 AbortSignal 是 process-local handle；协议不宣称整个 contribution 可 JSON 序列化或跨进程传输。
-- UI 不能折叠 raw Harness session event，也不能保存第二套 Agent 真相。
-- 每个 session/action ref MUST 带 epoch/revision；same-id new epoch、session switch、provider generation 更替后，旧 callback 返回 `BLUE_STALE`。
-- 危险 action、capturing overlay 和 item action MUST 由 Blue 在真实用户 dispatch 中铸造一次性 gesture；token 在 async handler settle/abort/unload 后失效。
-- renderer failure 只隔离当前 contribution；不能拆 Agent loop、当前 provider 或其他插件 surface。
-
-## 8. Scope、owner 与生命周期
-
-| Scope | 允许持有的状态 | 不得泄漏到 |
-| --- | --- | --- |
-| host | capability catalog、安装 policy、跨 session registry | session snapshot、renderer object |
-| agent | tool/persona/preset 等 Harness-owned state | Blue public DTO |
-| session | projection、epoch、structured action fencing | frontend focus/draft |
-| frontend tree | 当前 session binding、pane/overlay、draft、focus、active provider | durable domain truth |
-| provider Fiber | candidate subscription、timer、cache、in-flight callback | 其他 provider generation |
-
-所有 register/subscribe/timer/overlay/pending action MUST 绑定调用方 Cordis Fiber。dispose 必须幂等；unload 后的新写入、late callback 和 retained gesture MUST 被拒绝。
-
-Provider host 持续存活；切换顺序为：
-
-```text
-capture -> abort -> dispose -> activate -> restore
-```
-
-candidate 在选择前 inert。激活失败保留旧 provider 或回退 default；运行失败触发 generation-scoped breaker。安装顺序、priority 或 provider 自己的请求永远不能改变用户选择。
-
-对 `editor.provider`，上述 capture/restore 由 host 在内部保存并恢复同一个 editor engine、draft/history 和 focus；dispose/activate 只作用于 provider shell 自身资源。插件既不会收到 editor engine lifecycle handle，也不能借 provider swap替换或销毁 engine。
-
-公共 `bluePluginHost` 只能暴露版本、协商和已授予 API。owner attach、aggregate snapshot、notification observe、gesture mint 和强制 close 等 control-plane 操作 MUST 需要 bundle composition 创建的不可伪造 authority/lease；它们不得从 plugin-facing root 获得。承载完整 session/projection/action 真相的 raw owner source也不得作为普通 sibling 可 inject 的 Cordis service；第三方只能取得按 negotiated grant裁剪的 facade。Cordis `symbols.original` 或直接 service inject都不能成为权限升级路径。
-
-## 9. 错误、限制与 fallback
-
-所有公共失败返回 `BlueResult`，异常不得穿越插件边界。v1 runtime error taxonomy 至少包含：
-
-| Code | 含义 |
-| --- | --- |
-| `BLUE_API_INCOMPATIBLE` | API/capability semver 不相交 |
-| `BLUE_CAPABILITY_ABSENT` | required owner/surface 当前不存在 |
-| `BLUE_CAPABILITY_DENIED` | host policy 拒绝 capability |
-| `BLUE_RESOURCE_DENIED` | capability 存在但所需资源未获授权 |
-| `BLUE_DUPLICATE_ID` | plugin/contribution identity 冲突 |
-| `BLUE_INVALID_CONTRIBUTION` | schema、shape、node 或 callback 不合法 |
-| `BLUE_LIMIT_EXCEEDED` | quota、大小、深度、速率或并发超限 |
-| `BLUE_ABORTED` | caller、owner 或 unload 已中止操作 |
-| `BLUE_TIMEOUT` | owner-defined 有界 deadline 到期 |
-| `BLUE_STALE` | session/request/provider/item revision 已过期 |
-| `BLUE_UNAVAILABLE` | 运行时依赖暂不可用 |
-| `BLUE_ACTION_REJECTED` | 当前状态不允许该结构化 action |
-| `BLUE_INTERNAL_ERROR` | owner 已隔离的非预期错误；不得泄漏敏感细节 |
-
-Manifest/schema 错误有独立、稳定的 validation code。validator、installer 和 runtime parser MUST 使用同一 schema/semantic validator，不得各写一套字段规则。
-
-字符数、node 深度、collection、pane/overlay 数、刷新率和并发限制由 host grant 返回。协议可在兼容范围内调整默认 quota，但不能低于已接受 contribution 的当前 grant；超限只影响调用方。
-
-每个 capability MUST 在 catalog 中写明 absent、runtime failure、owner unload 和 provider failure fallback。没有 fallback 的 capability 不能 Stable。
-
-## 10. 版本演进
-
-- `schemaVersion` 只在 manifest 结构不兼容时递增。
-- `BLUE_API_VERSION` 使用 semver；Stable public type 删除、含义改变或 grant 收窄需要 major。
-- capability 自有 semver；新增 optional 字段、错误细分和新 optional capability 可以 minor。
-- Experimental capability 不构成 1.x 稳定承诺；每次变更必须更新其 capability prerelease/minor、fixture 和迁移说明。
-- Blue 产品版本由 release line 独立管理；`0.x` 产品可以承载稳定 `BLUE_API_VERSION 1.0.0`。
-- PR #77 合并时只能声明 `1.0.0-beta.1`。只有本文全部 Stable 条款和路线门禁通过后，才可发布 `1.0.0`。
-
-## 11. Conformance 与发布判定
-
-一个 capability 标记 Stable 前必须同时具备：
-
-1. schema request/resource 定义和生成的 TypeScript name/type；
-2. public API facet 与不可由第三方获得的 owner control plane；
-3. 默认 composition 中的真实 owner；
-4. 至少两个独立消费者，其中一个是 Blue official/reference consumer，另一个来自独立生态包；
-5. capability-absent/plain fallback；
-6. unit/compile contract，以及适用的 replay、abort、stale、unload、late callback、swap、width fixture；
-7. 从 `npm pack` tarball 在独立临时项目安装、只走 public exports 的 fixture；
-8. 当前和上一受支持 Harness exact line 的一致结果；
-9. package exports/files/tsdown、bundle composition、真实 profile 和人工验收证据；
-10. 中英文开发者文档、迁移说明、已更新的开发/迁移/fixture/validation skills，以及能用同一机器契约产出并验证 v1 插件的 Blue 创造模式。
-
-Fixture 报告的 `declared` 与 `executed` 必须完全相等，`skipped` 和 `failures` 必须为空。自动门禁不能替代需要真人判断的 profile 验收。
-
-创造模式是 schema、catalog、public API、scaffold、validator 与 conformance kit 的官方端到端消费者。它的发布证据 MUST 穿过“transient prototype -> 用户确认 -> 持久化 package -> shared validator -> current/previous Harness packed install”；persona、skills 或模板不得维护独立的 capability/version 名单，也不得通过 raw owner service 让旧接口继续存活。
-
-本文是长期协议真相；实现进度不写在这里。PR #77 的差异和 owner 状态由收敛矩阵维护，交付顺序由 v1 roadmap 维护。
+Public Beta 后，website「开发手册」按任务递进组织：开始开发、选择接入路径、架构、包与 manifest、UI capability、session 数据、生命周期、Web 迁移、创造模式、验证发布、案例和 API reference。Quickstart 不出现 control-plane、owner generation 或集成形态分类；内部实现文档不得成为作者完成第一个插件的前置阅读。PR #79 只冻结这项文档边界，不发布一套早于可执行 schema/catalog 的 v1 教程。

--- a/docs/blue-plugin-contract-v1.md
+++ b/docs/blue-plugin-contract-v1.md
@@ -1,0 +1,319 @@
+# Blue 插件协议 v1 目标态契约
+
+> 状态：**Draft / Target State**
+> 协议版本：`BLUE_API_VERSION 1.0.0`
+> 适用对象：Blue 插件作者、Blue capability owner、安装器、验证器和插件市场
+> 重要：本文描述 v1 发布时必须成立的目标态，不表示 `master` 或 PR #77 已全部实现。
+
+本文使用 MUST、MUST NOT、SHOULD、SHOULD NOT、MAY 表示规范强度。Blue 产品可以继续使用 `0.x` prerelease 版本；插件协议 `1.0.0` 是独立的兼容承诺。
+
+## 1. 目标与边界
+
+Blue 插件协议只管理 **Blue 自己拥有的前端权力，以及 Blue 对当前绑定 session 的受限 mediation gateway**。后者只裁剪公开 Harness snapshot/projection，不取得 domain authority。Capability 不是插件功能分类，也不是对 Harness API 的通用代理。
+
+```text
+公开 Cordis service       -> 插件直接 inject
+Harness projection        -> 受资源约束的 projections.read
+Host command/tool         -> 优先使用 Harness 自己的 registry
+仅存在于 HTTP/app 闭包    -> 上游先抽 renderer-neutral service
+Blue 前端自身权力         -> Blue capability
+```
+
+因此：
+
+- `cost.*`、`browser.*`、`rewind.*`、`market.*` 属于各 domain 插件，不是 Blue capability。
+- 不提供 generic `host.invoke`、raw Agent/Session/SessionEvent 或通用 `session.act`。
+- 插件配置和持久化直接使用公开的 `@deepseek-ai/dsh-settings` service；Blue 不再包装一套 storage 真相。
+- Blue API 不暴露 pi-tui、ANSI、raw terminal、DOM/React、terminal width、focus handle 或 renderer object。
+- Capability admission 是架构和最小权限边界，不是恶意代码沙箱。第三方 npm/GitHub 代码仍由用户决定是否信任。
+
+一个新 capability 只有同时满足以下条件，才 MAY 进入 Stable：
+
+1. 至少有两个独立消费者，其中至少一个是 Blue 官方/reference consumer，至少一个来自独立生态包；
+2. 现有公开 Cordis/Harness service、projection、command 或 tool 无法表达；
+3. authority 确实由 Blue frontend tree、当前 session binding 或 renderer 持有；若数据源属于 Harness，Blue 只提供受资源约束的当前绑定/projection adapter，不取得 domain authority；
+4. API renderer-neutral、按最小权限和资源授权；
+5. owner 缺失或 contribution 失败时存在可用 fallback；
+6. 有 official consumer、独立 packed fixture、unload/late-result、abort/stale、provider swap 或 width 证据（按能力适用）。
+
+## 2. 架构角色与三种分发形态
+
+Domain、Interaction、Renderer、Composition 是代码职责；`integrated`、`adapter`、`pure-ui` 是 manifest 所声明 Blue entry 的集成形态。两组概念 MUST NOT 混为一谈。`form` 不给同仓的 Web、daemon 或其他 sibling entry 分类，只约束该 Blue entry 的依赖闭包和运行时行为。
+
+| `form` | Blue entry 拥有或消费的内容 | 必须证明 | 禁止事项 |
+| --- | --- | --- | --- |
+| `integrated` | 同一分发包内的 headless domain 能力和 Blue interaction entry | Blue 不存在时 domain 仍可加载；domain 与 UI 有独立 scope/Fiber；UI 只消费公开 service/projection | domain import Blue；UI 成为业务真相；headless 因缺 renderer pending |
+| `adapter` | 对另一个插件公开 service/projection/action 的 Blue 适配 | `inject` 明确上游服务；adapter 无第二套业务状态；记录上游原生前端契约可用后的删除条件 | 穿透 Agent/Session；import 上游 internal；把 HTTP route 当 API |
+| `pure-ui` | 仅由 Blue 前端拥有的主题、导航、编辑辅助或静态 UI | 无 Harness domain 对象；缺 capability 时 inert/plain fallback；运行态限定在 frontend tree/provider Fiber，UI preference/history 只能经直接注入的公开持久化 service 保存 | 自建 domain 真相；依赖 renderer internal；绕过 host validation |
+
+`form` MUST 写入 manifest 并参与 validator 与 packed fixture，但它本身不授予任何 capability。一个 npm 包只有一个 manifest/form；一个 monorepo MAY 通过多个发布包提供多种 form。若 sibling Web entry 含 domain/runtime 逻辑，pure-ui 判定只看 Blue entry 可达依赖仍不够，fixture 还必须证明该 entry 加载时不启动或依赖这些逻辑。
+
+每个 Cordis entry 继续导出稳定 `name`、可选 `inject` 和 `apply(ctx)`。业务 service 依赖只在 `inject` 和 package peer/dependency 中声明，MUST NOT 在 Blue manifest 中复制第二份服务依赖表。
+
+## 3. 身份、分发与 manifest
+
+### 3.1 单一身份链
+
+每个 Blue v1 分发包 MUST 在 `package.json` 中声明：
+
+```json
+{
+  "name": "@scope/example-blue",
+  "blue": {
+    "manifest": "./blue.plugin.json"
+  }
+}
+```
+
+规则如下：
+
+- 一个包只有一个 v1 manifest；`blue.manifest` 是发现入口。
+- manifest `id` MUST 等于 npm `package.json.name`，用于安装去重、授权 namespace 和诊断。
+- manifest `entry` MUST 是该包 `exports` 中的公开 subpath（如 `.` 或 `./blue`），不能是 `lib/index.js` 等内部文件路径。
+- Cordis entry 导出的 `name` 是运行时插件名，profile patch row `id` 是 composition-local 名称；二者与 package id 是独立命名空间，不要求相等。
+- validator MUST 验证 manifest、exports、`files` tarball whitelist 和实际 packed tarball 闭包一致。
+- tarball integrity、来源 commit 和安装时间属于 installer lock/receipt，MUST NOT 由包作者写入 `blue.plugin.json`。
+
+### 3.2 v1 manifest 形状
+
+JSON Schema Draft 2020-12 是 manifest shape 的唯一机器真相；Schema 加版本化 semantic validator 构成完整机器契约。Semantic validator 只补跨字段、package/exports 和 semver 规则，不能重新定义 shape。下列 compatibility range 只演示字段和合法 semver，不替代发布时的受支持版本矩阵：
+
+```json
+{
+  "$schema": "https://dsh-blue.github.io/blue/schema/blue.plugin.v1.schema.json",
+  "schemaVersion": 1,
+  "id": "@scope/example-blue",
+  "entry": "./blue",
+  "api": "^1.0.0",
+  "compatibility": {
+    "blue": ">=0.1.0-rc.10 <1",
+    "harness": ">=0.1.1-rc.2 <0.2.0",
+    "node": "^22.19.0 || >=24.0.0"
+  },
+  "form": "adapter",
+  "capabilities": {
+    "required": [
+      { "name": "panes", "version": "^1.0.0" }
+    ],
+    "optional": [
+      {
+        "name": "projections.read",
+        "version": "^1.0.0",
+        "resources": { "keys": ["costUsage"] }
+      }
+    ]
+  }
+}
+```
+
+规范要求：
+
+- `schemaVersion`、`id`、`entry`、`api`、`compatibility`、`form`、`capabilities` 全部 required。
+- Schema 对未知字段使用 `additionalProperties: false`；扩展通过 schema/API 版本演进，不靠静默接受拼写错误。
+- `api`、compatibility range 和 capability `version` MUST 由真实 semver 实现验证，不能只用正则近似。
+- 同一 capability name 在 required、optional 两组内及跨组均 MUST 唯一。跨数组唯一性由共享 semantic validator 检查，不能假定标准 JSON Schema 能单独表达。
+- `resources` 使用按 capability 判别的 schema；不接受任意对象。
+- Experimental capability 只能出现在 `optional`，插件 MUST 在其缺失时继续加载。
+
+插件入口 MUST 导入并解析发布的同一份 `blue.plugin.json`，再交给 host；禁止在 `open()` 旁手写第二份 manifest。目标入口流程为：
+
+```ts
+const parsed = parseBluePluginManifest(rawManifest)
+if (!parsed.ok) return
+const opened = ctx.bluePluginHost.open(ctx, parsed.value)
+```
+
+## 4. Capability 协商
+
+目标公共形状：
+
+```ts
+interface BluePluginOpen {
+  readonly api: BluePluginApi
+  readonly grants: readonly BlueCapabilityGrant[]
+  readonly unavailableOptional: readonly BlueCapabilityUnavailable[]
+}
+
+interface BluePluginHost {
+  readonly version: string
+  open(consumer: BlueEffectOwner, manifest: BluePluginManifest): BlueResult<BluePluginOpen>
+}
+```
+
+协商 MUST 遵循：
+
+1. required capability、版本或所声明资源有任意一项不能满足，`open()` 整体失败且不留下 registration。
+2. optional capability 缺失、被 policy 拒绝或版本不兼容，不阻塞插件；原因进入 `unavailableOptional`，对应 API facet 不存在。
+3. required 项的资源是 all-or-nothing；optional 项 MAY 获得请求集合的子集，插件以 `grants` 为准。
+4. host 返回的 limits/quotas 是 grant 的一部分，不由插件自行宣称。
+5. API object 只包含实际获准 facet。注册之后 owner 临时替换时，host MUST 按该 capability 的 retained/fallback 规则处理，并在每次写入时复查 owner generation。
+6. capability version 独立于 Blue 产品版本；host 返回实际选择的精确版本。
+7. 同一 plugin Fiber 重复 `open()`、重复 contribution id、越权资源和 stale write 必须返回结构化错误。
+
+`BlueEffectOwner` 表示调用 entry 当前 Cordis Context/Fiber 的 effect ownership，不是普通插件可构造的权限 token。`open()` 成功后，host MUST 把该 Fiber 的 dispose 级联到所有注册、订阅和 in-flight action；插件 MAY 提前关闭自己的 handle，但不能关闭其他插件或 owner。
+
+## 5. Stable v1 Capability Catalog
+
+下表是 **v1 发布目标**；当前实现状态见 [PR #77 收敛矩阵](./blue-pr77-convergence-matrix.md)。
+
+| Capability | Authority owner / scope | 插件获得的 API | Resource / fallback | 候选证据 |
+| --- | --- | --- | --- | --- |
+| `commands` | interaction owner / frontend tree | 注册 Blue-local command，带 AbortSignal 和 user gesture | 名称、数量与执行并发受 grant 限制；缺失时插件直接使用自己的 domain command 或隐藏入口 | Lark、dsh-context |
+| `status` | status composition / frontend tree | 注册紧凑、非交互 `BlueStatusNode` | contribution 失败只隐藏自身；默认 status 永远保留 | Cost Meter、Peak Indicator、dsh-context |
+| `panes` | surface manager / frontend tree | 注册 header/left/right/bottom managed pane | placement、数量、尺寸由 grant 限制；窄屏按声明降级或隐藏 | Cost Meter、dsh-context、Conversation Navigator |
+| `overlays` | overlay manager / frontend tree | 在有效 user gesture 中打开 managed overlay | capturing overlay 数量受限；失败回到原 surface，不劫持 focus | Rewind、dsh-context |
+| `notifications.publish` | notification model / frontend tree | 发布有界、可去重 transient notice | 不包含全局 observe；sink 缺失时丢弃并返回 availability | Lark、OpenPencil |
+| `status.provider` | status provider composition / provider Fiber | 注册 inert provider candidate | 安装/priority 不自动激活；用户选择、dry render、LKG、breaker、default fallback | official default、dsh-status-bar minimal provider slice |
+| `session.read` | Blue app mediation gateway / current session | readonly current snapshot 与 subscription | `fields` 只允许 `identity/cwd/status/mode/model`；无会话返回 `null`；不得含写方法 | dsh-context、Conversation Navigator |
+| `projections.read` | Blue allowlisted gateway over Harness adapter / session | 从一致 cut 读取并订阅已授权 projection key | `keys` 必须精确 allowlist；值有大小上限；owner 缺失时该 key unavailable | dsh-context、Cost Meter |
+| `conversation.read` | conversation model owner / session | 有界分页读取 normalized entries 和 revision | 当前 session、cursor、page size 和内容类别受限；不返回 raw event log | Conversation Navigator、Rewind（service 前置） |
+| `conversation.navigate` | transcript/navigation owner / frontend tree | 按稳定 item ref 定位当前 conversation viewport | navigation 不修改 session；目标已淘汰时返回 stale | Conversation Navigator、Message Edit fixture |
+| `conversation.itemActions` | conversation interaction owner / frontend tree | 为 item 贡献适用性、label 和 user-triggered handler | ref 含 `sessionEpoch/itemId/revision`；Blue 只调度，业务执行调用插件自己的 service | Rewind（service 前置）、Message Edit（service 前置）、Bookmark/Tag reference fixture |
+| `theme.provider` | theme composition / provider Fiber | 注册 renderer-neutral semantic token candidate | 用户选择、token 完整性检查、default fallback；插件不能输出 ANSI/CSS | Catppuccin |
+| `settings.sections` | settings UI owner / frontend tree | 向 Blue 设置界面贡献 section/form/action | 只拥有呈现；schema、读写与持久化仍由插件注入的 `dsh-settings` service 负责 | Catppuccin、Lark |
+
+`commands` 只适用于需要 Blue UI result/gesture 语义的本地入口。能够由 Harness command registry 完整表达的 domain command SHOULD 直接注册到 Harness，避免双重发现源。
+
+### 5.1 Session 与 projection 资源
+
+`session.read` 的字段组含义固定如下：
+
+| Field group | 允许数据 |
+| --- | --- |
+| `identity` | opaque session id、`sessionEpoch`、snapshot `revision` |
+| `cwd` | 当前工作目录；没有申请时 provider 不应通过其他 Blue snapshot 获得 |
+| `status` | idle/running/waiting/failed 等 renderer-neutral 状态 |
+| `mode` | normal/plan/yolo 的只读有效值 |
+| `model` | provider/model/effort 的只读显示事实 |
+
+`status.provider` 固有 snapshot 只含 status composition 自己拥有的 busy、additive entries、viewport/theme facts。provider 若要 session id、cwd、mode 或 model，MUST 另行申请相应 `session.read` resource；不存在隐藏授权。
+
+`projections.read` 每次读取 MUST 返回 `sessionEpoch`、一致 cut 的 `asOfSeq` 和 immutable value。key unload、session switch、duplicate/older sequence 和 late callback MUST 被区分；generic reader 不允许任意字符串越过 manifest allowlist。
+
+### 5.2 Conversation item action
+
+`conversation.itemActions` 是扩展点，不是 Rewind 特化：
+
+```text
+Blue 提供 item ref + 当前 revision + user gesture + AbortSignal
+插件判断 isApplicable
+用户选择 action
+Blue 复查 epoch/revision 后调度
+插件调用自己 inject 的 domain service
+```
+
+Blue MUST NOT 定义 `rewind.apply`、`message.edit` 等业务 action。相同扩展点由 Rewind、Message Edit 和无 domain mutation 的 Bookmark/Tag reference fixture 共同验证泛化性；Peak Indicator 属 additive status，不能拿来充当 item action 证据。
+
+## 6. Experimental 与 Deferred
+
+### 6.1 Editor Experimental
+
+PR #77 证明 editor extension runtime 可以拥有 revision fencing、completion abort、submit transform 和 unload cleanup，但一个 `editor.extensions` 同时授予被动绘制、读取、写 draft 和改写提交的权力过宽。v1 将其拆为：
+
+| Capability | 权力 |
+| --- | --- |
+| `editor.decorations` | hint、diagnostic、before/after passive node 和结构化 action |
+| `editor.completions` | 接收有界 query/trigger，异步返回 completion；必须支持 abort/stale |
+| `editor.draft.read` | 读取当前 draft 的 readonly、revisioned snapshot |
+| `editor.draft.write` | 以 expected revision 提交 replace/insert 等结构化变更 |
+| `editor.submit.transform` | 在有界流水线中转换提交值；顺序、timeout、abort 和 rollback 明确 |
+
+以上在 v1 schema 中标为 Experimental，只能 optional。Composer History 是 draft read/write 压力 fixture；`@`/`#` completion 与 submit transformer 分别有独立 fixture，不能由一个“大而全”样例替代。公开 TypeScript 类型和 runtime admission MUST 接受同一 node 集合；PR #77 中 `before/after: BlueUiNode` 比 runtime passive subset 更宽的状态不能带入稳定声明。
+
+### 6.2 Deferred
+
+以下名字不进入 v1 public manifest：
+
+- `editor.provider`：等待 capture -> abort -> dispose -> activate -> restore、第二个真实 provider 和完整 draft/history/mode/attachments/focus/IME fixture。
+- `editor.keys` / contextual key interception：等待按 editor state、cursor edge 和 IME transaction 泛化；不得为 Composer History 单独开放 raw key handler。
+- tool presentation：现阶段由 Blue 官方 renderer 和 Harness tool presenter seam 处理。
+- conversation presentation policy：等待多个独立 renderer consumer。
+- full frontend/composition provider：只允许受信 bundle composition，不能伪装成普通动态插件 capability。
+
+以下名字被明确拒绝：`session.act`、`notifications.observe`（仅 owner/internal）、`storage`、`renderer.provider`、`host.invoke` 和任何 domain-specific capability。
+
+## 7. 数据、action 与 renderer-neutral 约束
+
+- 事件表示已发生事实，projection 表示当前状态，action 表示有结果的写请求。
+- 公共 snapshot/model MUST readonly、有限、有 scope，并且不能包含 Promise。异步只存在于 action/provider callback 边界。
+- UI node 是 renderer-neutral 的结构化数据。注册在同一进程内的 callback 和 AbortSignal 是 process-local handle；协议不宣称整个 contribution 可 JSON 序列化或跨进程传输。
+- UI 不能折叠 raw Harness session event，也不能保存第二套 Agent 真相。
+- 每个 session/action ref MUST 带 epoch/revision；same-id new epoch、session switch、provider generation 更替后，旧 callback 返回 `BLUE_STALE`。
+- 危险 action、capturing overlay 和 item action MUST 由 Blue 在真实用户 dispatch 中铸造一次性 gesture；token 在 async handler settle/abort/unload 后失效。
+- renderer failure 只隔离当前 contribution；不能拆 Agent loop、当前 provider 或其他插件 surface。
+
+## 8. Scope、owner 与生命周期
+
+| Scope | 允许持有的状态 | 不得泄漏到 |
+| --- | --- | --- |
+| host | capability catalog、安装 policy、跨 session registry | session snapshot、renderer object |
+| agent | tool/persona/preset 等 Harness-owned state | Blue public DTO |
+| session | projection、epoch、structured action fencing | frontend focus/draft |
+| frontend tree | 当前 session binding、pane/overlay、draft、focus、active provider | durable domain truth |
+| provider Fiber | candidate subscription、timer、cache、in-flight callback | 其他 provider generation |
+
+所有 register/subscribe/timer/overlay/pending action MUST 绑定调用方 Cordis Fiber。dispose 必须幂等；unload 后的新写入、late callback 和 retained gesture MUST 被拒绝。
+
+Provider host 持续存活；切换顺序为：
+
+```text
+capture -> abort -> dispose -> activate -> restore
+```
+
+candidate 在选择前 inert。激活失败保留旧 provider 或回退 default；运行失败触发 generation-scoped breaker。安装顺序、priority 或 provider 自己的请求永远不能改变用户选择。
+
+公共 `bluePluginHost` 只能暴露版本、协商和已授予 API。owner attach、aggregate snapshot、notification observe、gesture mint 和强制 close 等 control-plane 操作 MUST 需要 bundle composition 创建的不可伪造 authority/lease；它们不得从 plugin-facing root 获得。Cordis `symbols.original` 不能成为权限升级路径。
+
+## 9. 错误、限制与 fallback
+
+所有公共失败返回 `BlueResult`，异常不得穿越插件边界。v1 runtime error taxonomy 至少包含：
+
+| Code | 含义 |
+| --- | --- |
+| `BLUE_API_INCOMPATIBLE` | API/capability semver 不相交 |
+| `BLUE_CAPABILITY_ABSENT` | required owner/surface 当前不存在 |
+| `BLUE_CAPABILITY_DENIED` | host policy 拒绝 capability |
+| `BLUE_RESOURCE_DENIED` | capability 存在但所需资源未获授权 |
+| `BLUE_DUPLICATE_ID` | plugin/contribution identity 冲突 |
+| `BLUE_INVALID_CONTRIBUTION` | schema、shape、node 或 callback 不合法 |
+| `BLUE_LIMIT_EXCEEDED` | quota、大小、深度、速率或并发超限 |
+| `BLUE_ABORTED` | caller、owner 或 unload 已中止操作 |
+| `BLUE_TIMEOUT` | owner-defined 有界 deadline 到期 |
+| `BLUE_STALE` | session/request/provider/item revision 已过期 |
+| `BLUE_UNAVAILABLE` | 运行时依赖暂不可用 |
+| `BLUE_ACTION_REJECTED` | 当前状态不允许该结构化 action |
+| `BLUE_INTERNAL_ERROR` | owner 已隔离的非预期错误；不得泄漏敏感细节 |
+
+Manifest/schema 错误有独立、稳定的 validation code。validator、installer 和 runtime parser MUST 使用同一 schema/semantic validator，不得各写一套字段规则。
+
+字符数、node 深度、collection、pane/overlay 数、刷新率和并发限制由 host grant 返回。协议可在兼容范围内调整默认 quota，但不能低于已接受 contribution 的当前 grant；超限只影响调用方。
+
+每个 capability MUST 在 catalog 中写明 absent、runtime failure、owner unload 和 provider failure fallback。没有 fallback 的 capability 不能 Stable。
+
+## 10. 版本演进
+
+- `schemaVersion` 只在 manifest 结构不兼容时递增。
+- `BLUE_API_VERSION` 使用 semver；Stable public type 删除、含义改变或 grant 收窄需要 major。
+- capability 自有 semver；新增 optional 字段、错误细分和新 optional capability 可以 minor。
+- Experimental capability 不构成 1.x 稳定承诺；每次变更必须更新其 capability prerelease/minor、fixture 和迁移说明。
+- Blue 产品版本由 release line 独立管理；`0.x` 产品可以承载稳定 `BLUE_API_VERSION 1.0.0`。
+- PR #77 合并时只能声明 `1.0.0-beta.1`。只有本文全部 Stable 条款和路线门禁通过后，才可发布 `1.0.0`。
+
+## 11. Conformance 与发布判定
+
+一个 capability 标记 Stable 前必须同时具备：
+
+1. schema request/resource 定义和生成的 TypeScript name/type；
+2. public API facet 与不可由第三方获得的 owner control plane；
+3. 默认 composition 中的真实 owner；
+4. 至少两个独立消费者，其中一个是 Blue official/reference consumer，另一个来自独立生态包；
+5. capability-absent/plain fallback；
+6. unit/compile contract，以及适用的 replay、abort、stale、unload、late callback、swap、width fixture；
+7. 从 `npm pack` tarball 在独立临时项目安装、只走 public exports 的 fixture；
+8. 当前和上一受支持 Harness exact line 的一致结果；
+9. package exports/files/tsdown、bundle composition、真实 profile 和人工验收证据；
+10. 中英文开发者文档、迁移说明和已更新的开发/迁移/fixture/validation skills。
+
+Fixture 报告的 `declared` 与 `executed` 必须完全相等，`skipped` 和 `failures` 必须为空。自动门禁不能替代需要真人判断的 profile 验收。
+
+本文是长期协议真相；实现进度不写在这里。PR #77 的差异和 owner 状态由收敛矩阵维护，交付顺序由 v1 roadmap 维护。

--- a/docs/blue-plugin-host-lifecycle.md
+++ b/docs/blue-plugin-host-lifecycle.md
@@ -1,0 +1,90 @@
+# Blue Plugin Host 生命周期规范
+
+> 状态：**Draft / Internal**
+> 读者：Blue host、capability owner、bundle composition 和 conformance kit 维护者
+> 插件作者只需理解 website 开发手册中的可观察生命周期，不需要实现本文机制。
+
+## 1. 目标
+
+本规范把普通插件获得的数据/注册能力与 Blue 官方 owner 的管理能力分开，并冻结 owner 启停、重载和故障时的可观察结果。它约束权限和行为，不强制某个 TypeScript 类型或名为 `authority lease` 的实现。
+
+## 2. 内部术语
+
+- **消费方 Fiber**：调用 `bluePluginHost.open()` 并只获得 grant facets 的普通插件 Fiber。
+- **capability owner**：消费 contribution 或执行 capability action 的 Blue 官方 Fiber。
+- **control-plane authority**：attach owner、读取该 capability 的完整 contribution snapshot、观察内部 stream、mint gesture、semantic close 和推进 generation 的内部管理权限。
+- **owner generation**：一次成功 attach 的实例代号；新 generation 使旧 handle、callback 和异步结果 stale。
+- **owner gap**：capability 已由当前 composition 安装并获准，但 owner 尚未启动、正在 reload 或暂时失败。
+- **registration restore**：host 在 owner gap 中保留最新 inert registration，新 owner attach 后收到完整当前 snapshot。
+
+这些词不得成为 quickstart 的前置知识。对外只描述“注册是否保留、操作是否执行、返回什么结构化结果”。
+
+## 3. 权限不变量
+
+普通消费方 MUST NOT 通过以下受支持路径获得 control-plane authority：
+
+- plugin-facing root exports；
+- `bluePluginHost.open()` 返回值；
+- 可枚举或可直接 inject 的普通 Cordis service；
+- Cordis proxy unwrap / `symbols.original`；
+- 复制某个 owner helper、构造公开 DTO 或复用其他 Fiber handle。
+
+官方 owner 的权限必须由受信 composition 建立，绑定明确 capability 集合和 owner Fiber，并在 Fiber dispose 时撤销。实现 MAY 使用私有 closure、capability-scoped token、bundle-owned handle 或等价机制；只要 hostile sibling 无法取得、扩大、持久化或转交该权限。
+
+完整 session/projection/action truth 不能作为普通 sibling 可 inject 的 backing service。普通插件只能看到 grant 裁剪的 facade。该约束是进程内架构边界，不声称防御任意恶意同进程 JavaScript。
+
+## 4. Availability
+
+Host 至少区分：
+
+| 状态 | 含义 | Public 结果 |
+| --- | --- | --- |
+| unsupported | 当前 build/composition 没有 capability 或版本 | required admission 失败；optional unavailable |
+| unavailable | capability 已获准，但 owner 当前处于 gap | grant 保持；新 operation 返回 capability-specific fallback/error |
+| ready | 当前 generation 已 attach | 正常注册、读取和 action |
+| degraded | owner 在线，但单个 contribution/provider 失败 | 隔离调用方并执行 fallback，不扩大 grant |
+
+“代码包里存在 owner 实现”不等于 supported；当前 composition 必须实际安装 capability definition 和受保护的 attach path。App owner 在线但当前没有 session 是 ready 下的 `null`，不是 owner gap。
+
+## 5. 七项 Stable 能力的 gap 行为
+
+| Capability | Gap 中保留 | 新 operation |
+| --- | --- | --- |
+| `commands` | 最新 command definitions | 不 dispatch consumer handler |
+| `status` | 最新 additive nodes | 不 render/call contribution |
+| `panes` | 最新 pane definitions | 不 render/dispatch event |
+| `overlays` | 不保留 capturing state、handle 或 gesture | `open()` 返回 unavailable，不排队 |
+| `notifications.publish` | 不保留 notice queue | 返回未呈现结果，不补发 |
+| `session.read` | 只保留 subscription identity | read 返回 unavailable；恢复后先发当前 epoch snapshot |
+| `session.projections.read` | 只保留获准 key subscription identity | read 返回 unavailable；恢复后从当前 epoch 的一致 cut 开始 |
+
+Registration restore只恢复最新定义或订阅关系，不伪造 gap 中的连续事件流。旧 session value、overlay、gesture、action、notification、provider failure state 和 callback result均不得跨 generation replay。
+
+## 6. Generation 与 stale fencing
+
+- 每次合法 owner attach 建立新 generation。
+- dispatch、snapshot observe、gesture mint、semantic close 和 async completion 都检查当前 generation。
+- owner detach、consumer unload、session epoch change 或 AbortSignal 触发后，旧操作返回 `BLUE_STALE` 或 `BLUE_ABORTED`，不得产生副作用。
+- consumer registration 的 identity 可以跨 owner generation保留，但不能跨 consumer Fiber 生命周期保留。
+- same-id 新 session 必须由 session epoch 区分，不能只比较字符串 id。
+
+## 7. Failure isolation
+
+- 一个 contribution 的 getter、render、handler 或 provider 失败只影响自身。
+- owner 不得把缺失解释为授权扩大，也不得回退到 raw backing service。
+- 默认状态、主 transcript、editor engine 和 Agent loop 在插件失败时保持可用。
+- rate limit、size/depth/node count、timeout 和 concurrency limit 由 host grant/catalog 管理，而不是相信插件声明。
+
+## 8. Acceptance evidence
+
+内部 conformance 至少覆盖：
+
+1. hostile sibling 对 root exports、service injection、proxy unwrap、self-attach、aggregate observe、gesture mint 和 semantic close 的负例；
+2. owner boot ordering、reload、activation failure 和 dispose；
+3. retained registration只恢复最新 snapshot；
+4. overlay/action/notification/gesture/late callback不 replay；
+5. consumer unload、owner generation、session epoch 和 abort 的 stale fencing；
+6. contribution failure isolation 与默认 fallback；
+7. 当前/上一 Harness line 的独立 packed composition。
+
+PR #77 的 Beta 合并只要求上述可观察边界成立，不要求最终 authority representation 已冻结。协议 `1.0.0` 发布前，具体 owner-only exports、mapping、error taxonomy 和 generation report必须进入机器 contract 与 API declaration gate。

--- a/docs/blue-pr77-convergence-matrix.md
+++ b/docs/blue-pr77-convergence-matrix.md
@@ -1,0 +1,127 @@
+# PR #77 插件协议收敛矩阵
+
+> 状态：**Active merge control**
+> 基线：`master@1d0f01e`
+> 审计对象：PR [#77](https://github.com/dsh-blue/blue/pull/77) `p2/ui-api-refactor@03cb7e0`
+> merge-base：`1d0f01e`，PR 分支领先 33 commits
+> 目标规范：[Blue 插件协议 v1 目标态契约](./blue-plugin-contract-v1.md)
+
+2026-08-29 审计时，#77 的 CI 与 website check 为 green，但 GitHub 状态仍是 `BLOCKED / REVIEW_REQUIRED`；自动检查不替代本矩阵要求的 profile live acceptance。
+
+本文只回答“PR #77 的现有实现如何进入 master，并继续收敛到插件协议 v1”。它不是长期 API 真相。#77 合并并完成 v1 收敛后，本文移入 `docs/history/`。
+
+## 1. 总体判断
+
+PR #77 已形成四条可保留的纵向切片：
+
+1. canonical `BlueUiNode`、builders、admission validator 和唯一 pi-tui compiler；
+2. managed panes/overlays 与 focus、gesture、abort、buffer/replay；
+3. additive status 和用户选择的 `status.provider`；
+4. revision-fenced editor extension owner、completion/submit/action runtime 和 packed fixture。
+
+它尚未形成可直接冻结的 `1.0.0` 插件协议。当前三层状态并不一致：
+
+| 层 | 数量 | 当前事实 |
+| --- | ---: | --- |
+| manifest vocabulary | 10 | 包含 `session.read/session.act`、`editor.extensions/editor.provider` |
+| public host implemented set | 8 | 不含两个 session capability；另有内部 legacy `dock` |
+| 默认 bundle active owner | 7 | commands、status、notifications、panes、overlays、editor.extensions、status.provider；另有 legacy dock owner |
+
+`editor.provider` 只有 type/registry，没有 selection/swap owner；`session.read/session.act` 仍明确拒绝。manifest、validator、website 与 public root 还存在身份、权限和稳定性矛盾。
+
+因此采用两级门禁：
+
+- **BETA-MERGE**：阻止 #77 以已知不安全或误称 Stable 的状态进入 master。
+- **V1-RELEASE**：允许 Beta 基础先合并，但在 `BLUE_API_VERSION 1.0.0` 发布前必须完成。
+
+裁决含义：
+
+- `KEEP`：实现方向和公共语义可保留；仍需按目标契约补证据。
+- `CHANGE`：保留纵向实现，但修改权限、shape、稳定性或 owner 边界。
+- `REMOVE`：不得进入目标 v1 public surface；兼容代码按依赖顺序删除。
+- `ADD`：PR #77 没有该目标能力或机器契约，需要后续实现。
+
+## 2. 收敛矩阵
+
+| Surface | #77 当前状态 | 裁决 | v1 目标 | Owner | Gate / 必需证据 |
+| --- | --- | --- | --- | --- | --- |
+| `BlueUiNode` wire | `packages/api/src/contracts.ts` 中闭合 union；纯 clone/freeze；callback 与 signal 仍为 process-local | KEEP | renderer-neutral canonical tree；文档明确“数据可检查”不等于整个 contribution 可跨进程序列化 | api owns wire | V1：hostile realm/getter/cycle/depth/node/collection corpus；外部 tarball consumer |
+| `@dsh-blue/blue-ui` builders | 纯 builder、caller-safe，官方 panel/dialog/status 已消费 | KEEP | 只做 ergonomics，不另立 wire truth；输出必须通过同一 validator | ui package | V1：builder/wire/API declaration diff；至少两个外部插件共用 |
+| core validator/compiler | core 是唯一 admission/compiler 和 pi-tui boundary；已有 exhaustive/width tests | KEEP | 非 core 包不接触 pi-tui、ANSI、terminal width/focus；compiler failure 隔离 contribution | core | V1：2..120 width/hostile node；public kit packed import |
+| `panes` | host registry、每插件配额、buffer/replay、surface bridge、semantic events、responsive layout 已实现 | KEEP | Stable managed surface；明确 renderer owner 暂未 attach 时的 retained queue/replay | core surface owner | V1：header/right/bottom、narrow、owner unload/reload、focus restore、late event、20/40/80/120 packed fixture |
+| `overlays` | one-shot gesture、capturing 配额、FIFO/latest-wins、abort/close/focus restore 已实现 | KEEP | Stable managed overlay；普通插件不能主动开 capturing overlay | core overlay owner | V1：gesture expiry、double submit、unload、owner swap、timeout、hostile sibling |
+| additive `status` | narrow recursive status node、独立 revision、transcript owner/compiler 已实现 | KEEP | Stable additive status；非交互、不能夺取 footer composition | transcript status owner | V1：external status packed fixture、width、render throw、unload/reload |
+| `status.provider` | inert candidates、settings selection、dry render、same-session LKG、cross-session default、3/60s breaker、fallback 已实现 | CHANGE | 保留 provider 事务；专用 snapshot 不隐式带 session id/cwd/model；需要时显式申请 `session.read` resource；加入 session epoch/revision | transcript composition + settings | V1：owner absent、theme/session switch、stale generation、selection persistence、failure attribution、真实 profile swap |
+| `commands` | interaction bridge 映射到 Harness commands，具备 AbortSignal、owner-minted gesture、duplicate rollback、unload | KEEP | 只承诺 Blue-local UI command；能直接注册 Harness command 的 domain 插件继续走 host service | interaction owner | V1：packed command、late settlement/unload、gesture chain；文档避免双 command discovery |
+| `notifications` | 一个 capability 同时返回 publish/subscribe；owner bridge 使用全局 observer | CHANGE | public 只保留 `notifications.publish`；observe 属 owner control plane；定义 dedupe/replace/duration/priority 和动态 rate limit | notification model + interaction renderer | V1：publisher 隔离、普通插件不能观察其他插件、sink absent、rate/dedupe、unload/late publish |
+| `editor.extensions` | `5a24f54` 后已有真实 owner：passive node admission、`/ @ #` completion、action gesture、submit transform、revision/abort/unload 和 packed fixture | KEEP + CHANGE | Beta 保留完整纵向实现；v1 capability 拆为 decorations、completions、draft.read、draft.write、submit.transform，均为 Experimental/optional | interaction editor owner | BETA-MERGE：不得称 Stable；`before/after` 静态 `BlueUiNode` 与 runtime passive subset 收窄一致。V1：逐项最小授权；真实 editor input/completion apply/submit profile 路径；draft/history/IME 不丢 |
+| `editor.provider` | public type、registry 和 shell validator 存在；默认 bundle 没有 selection/swap owner，`open()` 返回 absent | REMOVE (Stable) | 不进入 v1 manifest/root；待完整 capture/abort/dispose/activate/restore 和第二个真实 provider 后另行提案 | future interaction/core owner | BETA-MERGE：从 Stable capability 声明移除或明确 Deferred。未来：draft/history/mode/attachments/focus/IME、failure rollback、unload |
+| flat `capabilities[]` | required/optional、capability version、resource grant、form 均不可表达；`open()` all-or-nothing | CHANGE | 对象式 required/optional request；每项 `{name, version, resources?}`；返回 negotiated grants | api/schema + host | V1：positive/negative schema corpus；required fail、optional degrade、resource subset/denial、duplicate cross-group |
+| manifest identity | inline 字段多为 optional；分发文档要求 root JSON；quickstart 不生成 JSON；id/name/row 是否相等互相矛盾 | CHANGE | `package.json.blue.manifest` 唯一发现入口；id=package name；entry=exports subpath；Cordis name/row id 独立 | schema + installer | V1：packed package、exports/files、runtime import 同一 JSON、identity negative corpus |
+| `integrity` author field | manifest 接受作者提供的 tarball digest | REMOVE | integrity/source commit 放 installer receipt/lock，不能由被验证包自证 | installer | V1：安装 receipt 和 source pin fixture；schema 拒绝 author integrity |
+| semver admission | manifest 用字符正则；host 只用 `/^\^?1/` 近似 API major | CHANGE | 真实 semver range parse/intersection；API、product、Harness、Node、capability version 分离 | schema/runtime admission | V1：prerelease、union、upper bound、invalid range corpus |
+| `session.read` | manifest 有名字，host 明确 denied；`BlueSessionReader` 同时含 `current/subscribe/request`，snapshot 无 epoch/revision | CHANGE | 纯 readonly facet；按 identity/cwd/status/mode/model resource 裁剪；snapshot/subscription 带 epoch/revision | app + narrow harness adapter | V1：same-id new epoch、session switch、headless absence、bounded snapshot、no Agent/Session/write leakage |
+| `session.act` | manifest 有名字但永远 denied；未来若复用 `BlueSessionReader` 会让 read grant 获得 followup/steer/interrupt | REMOVE | v1 无通用 session write；按真实业务 action 或 `conversation.itemActions` 扩展点设计 | domain plugin owns action | BETA-MERGE：移出公开 vocabulary。V1：negative schema/API fixture |
+| owner helper root exports | api root 导出 attach/snapshot/subscribe/mint/close；官方 bridge 用 Cordis `symbols.original` 解包后调用 | CHANGE | public host 只有 version/open/data facets；control plane 要求 bundle composition 创建的 authority/lease，普通 sibling 无法获得 | bundle + api host | **BETA-MERGE blocker**：hostile sibling 证明 unwrap/self-attach/snapshot/mint/close 均失败；官方 owner reload 保持正常 |
+| aggregate owner snapshot | 一个 snapshot 同时含全部 capability contribution 与 revisions | CHANGE | owner subscription 按 capability/lease 窄化；owner 不能观察无关插件数据 | capability owners | BETA-MERGE：至少隔离公共 root。V1：per-owner subscription 和 cross-capability negative fixture |
+| `BluePluginDefinition.apply(api: unknown)` | public type 无 loader/runtime consumer | REMOVE | v1 使用真实 Cordis entry + parsed manifest + negotiated typed API；不保留占位符 | api/loader | BETA-MERGE 或首个 schema PR 删除；compile negative fixture |
+| error taxonomy | stale/timeout/unavailable/resource denial 不可区分，多处压入 `BLUE_ACTION_REJECTED/ABORTED` | CHANGE | 采用目标契约的 negotiation/admission/execution 错误分类；无异常跨边界 | api | V1：每个 code 有可复现 fixture，message 不承担机器语义 |
+| legacy `dock` | public validator 拒绝，但 `BlueHostManifest`、host aggregate、transcript bridge和 bundle e2e 仍消费 | REMOVE | 官方 bottom surfaces 迁到 `panes` 后物理删除 type/registry/snapshot/bridge；旧 manifest 给明确迁移诊断 | transcript/core panes | V1：`rg` 无 public/internal dock compatibility；bundle e2e 改走 bottom pane |
+| legacy `panels/editor/tools` | migration validator 仍识别这些旧名字；无 v1 owner/API | REMOVE | 不进入新 schema、catalog 或 API root；validator 只返回明确迁移诊断 | schema/validator | V1：negative corpus；网站不再把旧名字描述为 future capability |
+| `projections.read` | app 内部 reader 可按任意字符串返回 `unknown`，没有 public resource gate | ADD | manifest 精确 key allowlist；一致 cut、size bound、epoch/asOfSeq、key unload 语义 | app/harness adapter | V1：dsh-context + Cost Meter，replay/resume、duplicate/older seq、key unload、late callback |
+| conversation APIs | conversation projection存在，但无 public bounded reader、navigate 或 item action registry | ADD | `conversation.read/navigate/itemActions`；item action 只调度，业务执行留在插件 service | conversation + transcript/interaction | V1：Navigator、Rewind、Message Edit、Bookmark/Tag reference；pagination/stale/gesture/unload |
+| `theme.provider` | frontend theme model存在；公开插件没有 provider negotiation/selection contract | ADD | semantic token candidate、用户选择、validation、fallback；无 ANSI/CSS | frontend/core composition | V1：Catppuccin，token completeness、swap failure、unload、narrow/width |
+| `settings.sections` | Blue 有内部 settings panel 和 dsh-settings owner；无第三方 section contract | ADD | 只贡献 settings UI；plugin config/schema/persistence 直接 inject `dsh-settings` | interaction settings UI | V1：Catppuccin + Lark，read-only backend、conflict、unload；证明无 Blue storage |
+| JSON Schema / TS manifest | 没有独立 schema；script 只检查字段存在且不复用 runtime validator | ADD | Draft 2020-12 schema 为源，生成 TS type；Ajv/validator/installer/runtime 共用；drift gate | api/schema | V1：schema corpus、generated diff、published URL/subpath、真实 tarball |
+| public API plane | owner helpers、Stable/Experimental、plugin-facing types混在 root | CHANGE | root 只导出 Stable；Experimental 走明确 subpath/标记；owner authority 不可由普通插件取得 | api package | BETA-MERGE：稳定性声明收窄。V1：API declaration report、exports/files/tsdown triangle |
+| docs/skills | website manifest/quickstart/seams、package README、skills 和代码 capability 状态漂移 | CHANGE | contract 是目标真相；package AGENTS 是当前实现；能力表从 schema/catalog 校验生成；中英同步 | docs + package owners | BETA-MERGE：不得把 absent/denied 写成 Stable。V1：docs build、parity、examples packed install、skill eval |
+| `BLUE_API_VERSION` | root与host已经声明 `1.0.0` | CHANGE | #77 只作为 `1.0.0-beta.1` 合并；全部 V1 gate 通过后一次性升 `1.0.0` | api/release | **BETA-MERGE blocker**：不产生错误稳定承诺；V1 release report |
+
+## 3. 相关 PR 处置
+
+- PR [#72](https://github.com/dsh-blue/blue/pull/72) 与 #77 修改同一 UI 蓝图和索引，但保留了更旧的 API version、overlay/event 和实施裁决。它 MUST 关闭为被 #77 supersede，不能再单独合并。
+- PR [#76](https://github.com/dsh-blue/blue/pull/76) 文件上可独立处理，但 capability 调研仍基于旧四能力和 `dock`。若合并，MUST 标成带日期的需求快照或先按 #77 更新；它不是规范来源。
+- `docs/blue-ui-component-enhancement.md` 在 #77 中既有目标蓝图也有已经过期的“尚未实现”进度。Beta 合并前先修正事实；待本矩阵接管进度且真人验收完成后，再单独归档。
+
+## 4. #77 Beta 合并前顺序
+
+以下工作保持在 #77 分支，完成后它才适合作为 Beta UI foundation 合并：
+
+1. **冻结新基线**：合入本契约文档，更新 PR 描述到 `03cb7e0` 或当时最新 head，列出 Stable/Experimental/Deferred 实际状态。
+2. **降级版本承诺**：`BLUE_API_VERSION` 与 host version 改为 `1.0.0-beta.1`；`^1.0.0` 示例不得声称当前可用。
+3. **隔离 control plane**：从 plugin-facing root 移除 owner helper；引入 composition authority/lease，禁止 `symbols.original` 成为 sibling 权限升级。
+4. **收窄公开 vocabulary**：删除 `session.act` 和 Stable `editor.provider`；`session.read` 在 owner 落地前不得伪装可用；editor extensions 标 Experimental。
+5. **保持成熟纵向切片**：canonical UI、panes/overlays、status、status provider、editor runtime 不回退；所有现有 unit/packed/width 证据继续绿。Editor packed fixture 已证明 host binding、replay、abort 和 unload，但 profile dogfood 还要穿过真实 input、completion apply 与 submit barrier。
+6. **修正文档事实**：package README/AGENTS 与 website 只能描述实际 owner；未实现目标链接到本文和 roadmap。
+7. **完整 worktree 验收**：全门禁、专用 profile dogfood、用户 live-test；未明确“验收通过”前不合并 #77。
+
+这一步不要求把整个 v1 roadmap 塞回 #77。manifest/schema 和新 ecosystem capability 在 master 上用后续小 PR 收敛，避免 #77 继续膨胀。
+
+## 5. v1 收敛依赖顺序
+
+```text
+Beta merge
+  -> JSON Schema + identity + semver + generated manifest type
+  -> negotiated grants + public/control plane + error taxonomy
+  -> existing UI surface cleanup (notifications split, dock removal)
+  -> session/projection/conversation owners
+  -> theme/settings owners
+  -> editor Experimental split
+  -> synthetic + ecosystem packed fixtures
+  -> skills + bilingual docs
+  -> 1.0.0 release gate
+```
+
+每一行关闭时必须把“当前实现、测试证据、owner、bundle row、fixture report”填回矩阵，不能只把状态改成 Done。
+
+## 6. 归档条件
+
+满足以下条件后，本矩阵移动到 `docs/history/blue-pr77-convergence-matrix.md`：
+
+- #77 已按 Beta 规则合并；
+- 所有 BETA-MERGE 行关闭；
+- 所有 Stable v1 capability 通过 conformance；
+- `BLUE_API_VERSION` 已发布为 `1.0.0`；
+- 长期行为可完全由目标契约、生成 schema/API reference 和 package AGENTS 解释。
+
+归档时记录最终 merge commit、协议发布 tag、fixture exact Harness lines、profile dogfood 和人工验收结论。

--- a/docs/blue-pr77-convergence-matrix.md
+++ b/docs/blue-pr77-convergence-matrix.md
@@ -2,8 +2,8 @@
 
 > 状态：**Active merge control**
 > 基线：`master@1d0f01e`
-> 审计对象：PR [#77](https://github.com/dsh-blue/blue/pull/77) `p2/ui-api-refactor@c9e1600`
-> merge-base：`1d0f01e`，PR 分支领先 48 commits
+> 审计对象：PR [#77](https://github.com/dsh-blue/blue/pull/77) `p2/ui-api-refactor@c89c714`
+> merge-base：`1d0f01e`，PR 分支领先 54 commits
 > 目标规范：[Blue 插件协议 v1 目标态契约](./blue-plugin-contract-v1.md)
 
 2026-08-29 审计时，#77 的 CI 与 website check 为 green，但 GitHub 状态仍是 `BLOCKED / REVIEW_REQUIRED`；自动检查不替代本矩阵要求的 profile live acceptance。
@@ -53,13 +53,13 @@ PR #77 已形成六条可保留的实现基座：
 | `panes` | host registry、每插件配额、buffer/replay、surface bridge、semantic events、responsive layout已实现；仓内 packed examples 覆盖 header/right/bottom、20/40/80/120、absent/admission/unload | KEEP | Stable managed surface；明确 renderer owner 暂未 attach 时的 retained queue/replay | core surface owner | V1：在真实 surface manager 补 narrow、owner reload、focus restore、late event；独立生态 packed consumer |
 | `overlays` | one-shot gesture、capturing 配额、FIFO/latest-wins、abort/close/focus restore 已实现；仓内 packed example 覆盖 atomic capability rejection、gesture、unload/late use | KEEP | Stable managed overlay；普通插件不能主动开 capturing overlay | core overlay owner | V1：真实 renderer 的 focus/timeout/double submit/owner swap、hostile sibling；独立生态 packed consumer |
 | additive `status` | narrow recursive status node、独立 revision、transcript owner/compiler 已实现 | KEEP | Stable additive status；非交互、不能夺取 footer composition | transcript status owner | V1：external status packed fixture、width、render throw、unload/reload |
-| `status.provider` | inert candidates、settings selection、dry render、same-session LKG、cross-session default、3/60s breaker、fallback 已实现；仓内 packed candidate 的 13/13 双线证据来自 `b5f3310` checkpoint，只验证 admission/width/unload | CHANGE | 保留 provider 事务；专用 snapshot 不隐式带 session id/cwd/model；需要时显式申请 `session.read` resource；加入 session epoch/revision | transcript composition + settings | V1：final-head packed rerun、owner absent、theme/session switch、stale generation、selection persistence、failure attribution、真实 profile swap；dsh-status-bar 外部 slice |
+| `status.provider` | inert candidates、settings selection、actual-width dry render、same-session LKG、cross-session default、3/60s breaker、fallback 已实现；最终候选的 transcript packed fixture 在双 Harness 线各 13/13，覆盖 selection、refresh、inert、fallback、owner unload/reload 与 late handle | CHANGE | 保留 provider 事务；专用 snapshot 不隐式带 session id/cwd/model；需要时显式申请 `session.read` resource；加入 session epoch/revision | transcript composition + settings | V1：snapshot/resource 收窄、theme/session switch、stale generation、failure attribution与 dsh-status-bar 外部 slice；真实 profile swap 的自动证据已完成，真人验收仍 pending |
 | `commands` | interaction bridge 映射到 Harness commands，具备 AbortSignal、owner-minted gesture、duplicate rollback、unload | KEEP | 只承诺 Blue-local UI command；能直接注册 Harness command 的 domain 插件继续走 host service | interaction owner | V1：packed command、late settlement/unload、gesture chain；文档避免双 command discovery |
 | `notifications` | 一个 capability 同时返回 publish/subscribe；任一普通 consumer 可收到其他插件 publish 的全局通知，owner bridge 另有 observer | CHANGE | public 只保留 `notifications.publish`；observe 属 owner control plane；定义 dedupe/replace/duration/priority 和动态 rate limit | notification model + interaction renderer | **BETA-MERGE blocker**：无条件移除普通 consumer subscribe并将 owner observe收回受 authority 保护的 control plane，不能靠降为 Experimental 保留越权观察。V1：publisher 隔离、sink absent、rate/dedupe、unload/late publish |
-| `editor.extensions` | `5a24f54` 后已有真实 owner：passive node/action、`/ @ #` completion、submit transform、revision/abort/unload；9/9 双线 packed 证据来自 `03cb7e0` checkpoint；当前不提供 draft read/write | KEEP + CHANGE | Beta 保留纵向实现；v1 将现有 decorations/completions/submit.transform 拆权，并另增 draft.read/write，均为 Experimental/optional | interaction editor owner | BETA-MERGE：不得称 Stable且须 final-head packed rerun；`before/after` 静态 `BlueUiNode` 与 runtime passive subset 收窄一致。V1：逐项最小授权；真实 editor input/completion apply/submit profile 路径；draft/history/IME 不丢 |
-| `editor.provider` | `fe48004` 后已有真实 owner、persisted user selection、actual-width dry render、同一 editor/focus 上的原子 shell swap、LKG/breaker/default fallback、abort/stale/unload；仓内 packed candidate 存在；public type仍只有 `render/onEvent`，未冻结 activate/dispose 或无状态 shell lifecycle语义 | KEEP + CHANGE | 作为 Experimental optional 的 host-owned editor shell provider；恰好一个 `editor-control`，不授予 draft/cursor/history/IME/raw-key 或 engine ownership；mode 另走 `session.read` grant | interaction owner + core compiler | BETA-MERGE：flat manifest阶段退出 public Stable surface、保留 internal/reference runtime。Experimental 发布：optional schema/subpath、public lifecycle、final-head packed和统一 profile。未来 Stable：独立生态 provider等完整门禁 |
+| `editor.extensions` | 已有真实 owner：passive node/action、`/ @ #` completion、submit transform、revision/abort/unload；最终候选的 interaction packed fixture 在双 Harness 线各 11/11，含 extension owner replay/inert 与 callback abort/unload/late rejection；当前不提供 draft read/write | KEEP + CHANGE | Beta 保留纵向实现；v1 将现有 decorations/completions/submit.transform 拆权，并另增 draft.read/write，均为 Experimental/optional | interaction editor owner | BETA-MERGE：不得称 Stable；`before/after` 静态 `BlueUiNode` 与 runtime passive subset 收窄一致。V1：逐项最小授权；真实 editor input/completion apply/submit；draft/history/IME 不丢 |
+| `editor.provider` | 已有真实 owner、persisted user selection、actual-width dry render、同一 editor/focus 上的原子 shell swap、LKG/breaker/default fallback、abort/stale/unload；最终候选的 interaction 11/11 双线 fixture 覆盖 selection/identity/fallback/inert、owner unload/replay、event abort/late；public type仍只有 `render/onEvent`，未冻结 activate/dispose 或无状态 shell lifecycle语义 | KEEP + CHANGE | 作为 Experimental optional 的 host-owned editor shell provider；恰好一个 `editor-control`，不授予 draft/cursor/history/IME/raw-key 或 engine ownership；mode 另走 `session.read` grant | interaction owner + core compiler | BETA-MERGE：flat manifest阶段退出 public Stable surface、保留 internal/reference runtime。Experimental 发布：optional schema/subpath、public lifecycle与真人统一 profile验收。未来 Stable：独立生态 provider等完整门禁 |
 | flat `capabilities[]` | required/optional、capability version、resource grant、form 均不可表达；`open()` all-or-nothing | CHANGE | 对象式 required/optional request；每项 `{name, version, resources?}`；返回 negotiated grants | api/schema + host | V1：positive/negative schema corpus；required fail、optional degrade、resource subset/denial、duplicate cross-group |
-| manifest identity | 已有 `package.json.blue.manifest` pointer、root JSON、quickstart 和六个 packed examples；但 validator 仍硬找 root JSON，`entry` 写内部 `./lib/index.js`，源码在 `open()` 旁再手写 manifest，并要求 entry `name`=package | CHANGE | `package.json.blue.manifest` 唯一发现入口；id=package name；entry=exports subpath；Cordis name/row id 独立 | schema + installer | V1：packed package、exports/files、runtime import 同一 JSON、identity negative corpus |
+| manifest identity | 已有 `package.json.blue.manifest` pointer、root JSON、quickstart 和八包 example suite（user kit、六个 runnable plugins、composition）；但 validator 仍硬找 root JSON，`entry` 写内部 `./lib/index.js`，源码在 `open()` 旁再手写 manifest，并要求 entry `name`=package | CHANGE | `package.json.blue.manifest` 唯一发现入口；id=package name；entry=exports subpath；Cordis name/row id 独立 | schema + installer | V1：packed package、exports/files、runtime import 同一 JSON、identity negative corpus |
 | `integrity` author field | manifest 接受作者提供的 tarball digest | REMOVE | integrity/source commit 放 installer receipt/lock，不能由被验证包自证 | installer | V1：安装 receipt 和 source pin fixture；schema 拒绝 author integrity |
 | semver admission | manifest 用字符正则；host 只用 `/^\^?1/` 近似 API major | CHANGE | 真实 semver range parse/intersection；API、product、Harness、Node、capability version 分离 | schema/runtime admission | V1：prerelease、union、upper bound、invalid range corpus |
 | `session.read` | `f375c13` 已拆出纯 readonly `current/subscribe` facade、真实 app owner、monotonic revision、clone/freeze、replay/owner-gap fencing；但完整 `blueSessionReader` 仍是任意 sibling可 inject 的 Cordis service，可绕过 fields grant | CHANGE | 保留 readonly seed，按 identity/cwd/status/mode/model resource 裁剪，并加入明确 `sessionEpoch`；raw source只对 authority owner可见 | app + narrow harness adapter | **BETA-MERGE blocker**：隐藏/authority-gate raw reader并加 hostile direct-inject fixture。V1：same-id new epoch、session switch、headless absence、bounded snapshot、resource denial、no Agent/Session/write leakage |
@@ -76,36 +76,36 @@ PR #77 已形成六条可保留的实现基座：
 | `settings.sections` | Blue 有内部 settings panel 和 dsh-settings owner；无第三方 section contract | ADD | 只贡献 settings UI；plugin config/schema/persistence 直接 inject `dsh-settings` | interaction settings UI | V1：Catppuccin + Lark，read-only backend、conflict、unload；证明无 Blue storage |
 | JSON Schema / TS manifest | 没有独立 schema；script 只检查字段存在且不复用 runtime validator | ADD | Draft 2020-12 schema 为源，生成 TS type；Ajv/validator/installer/runtime 共用；drift gate | api/schema | V1：schema corpus、generated diff、published URL/subpath、真实 tarball |
 | public API plane | owner helpers、Stable/Experimental、plugin-facing types混在 root | CHANGE | root 只导出 Stable；Experimental 走明确 subpath/标记；owner authority 不可由普通插件取得 | api package | BETA-MERGE：稳定性声明收窄。V1：API declaration report、exports/files/tsdown triangle |
-| docs/skills | website/README/skills 已补实际 session/editor owner 和示例，但把 flat manifest、`session.act`、editor surfaces 与 owner helpers一并描述成 Stable 1.0 | CHANGE | contract 是目标真相；package AGENTS 是当前实现；能力表从 schema/catalog 校验生成；中英同步 | docs + package owners | **BETA-MERGE blocker**：按 Stable/Experimental/Rejected 重写，不把“已实现”当“已冻结”。V1：docs build、parity、examples packed install、skill eval |
+| docs/skills/创造模式 | website/README 与两组 skills 把 flat manifest、`session.act`、notification subscribe、旧 identity 和 editor surfaces描述成 Stable 1.0。创造模式已有 isolate、真实 `cordis_define/run/update/stop/rollback` 与 durable-buffer e2e，但只检查 skill discovery，不执行 bundled skills，也不生成、validate 或 packed-install 持久包；仓内 fixture还拒绝 workspace 外包 | CHANGE | contract 是目标真相；能力表、模板与 transient request从 schema/catalog 生成；创造模式成为可生成三种 form、识别 zero-API并验证持久包的 official consumer；中英同步 | bundle preset + authoring toolkit + docs | **BETA-MERGE blocker**：按 Stable/Experimental/Rejected 重写，不把“已实现”当“已冻结”。V1：四类 skill eval、外部可调用 validator/fixture、完整 prototype -> confirm -> package -> 双线 packed e2e |
 | `BLUE_API_VERSION` | root与host仍声明 `1.0.0`；examples、README、website 和 rc.1 release note均按 `^1.0.0`/Stable 推广 | CHANGE | #77 只作为 `1.0.0-beta.1` 合并；全部 V1 gate 通过后一次性升 `1.0.0` | api/release | **BETA-MERGE blocker**：不产生错误稳定承诺；V1 release report |
 
 ## 3. 相关 PR 处置
 
-- PR [#72](https://github.com/dsh-blue/blue/pull/72) 与 #77 修改同一 UI 蓝图和索引，但保留了更旧的 API version、overlay/event 和实施裁决。它 MUST 关闭为被 #77 supersede，不能再单独合并。
+- PR [#72](https://github.com/dsh-blue/blue/pull/72) 与 #77 修改同一 UI 蓝图和索引，但保留了更旧的 API version、overlay/event 和实施裁决。它不能再单独合并；按 #77 当前 merge gate，在 #77 真人验收并合并后关闭为 superseded。
 - PR [#76](https://github.com/dsh-blue/blue/pull/76) 文件上可独立处理，但 capability 调研仍基于旧四能力和 `dock`。若合并，MUST 标成带日期的需求快照或先按 #77 更新；它不是规范来源。
-- `docs/blue-ui-component-enhancement.md` 顶部仍称“产品实现尚未开始”，W5 段仍把已完成工作写成 future，而 W6 段又记录 W6-1..4 完成。Beta 合并前先消除这组内部矛盾；待本矩阵接管进度且真人验收完成后，再单独归档。
-- #77 的 PR body 仍停在“只到 W3/G3”、177 files/2730 tests/check:lib 69 和旧 G3 acceptance；它 MUST 更新到当前 head、W4-W6 scope、实际门禁与仍缺的最终验收。G3 acceptance 早于 W4-W6，不能覆盖其后的全部实现提交。
+- `docs/blue-ui-component-enhancement.md` 已更新为 W1-W6 最终候选账目，并明确真人验收、合并和候选发布未发生；该陈旧事实项已关闭。待本矩阵接管进度且真人验收完成后，再单独归档。
+- #77 的 PR body 已更新 W1-W6 scope、自动门禁与仍缺的真人验收，但 `Final candidate head: 3f0e42b` / 2959 tests 落后最新 `c89c714` / 2960 tests 一次只增加 bundle composition guard 的提交；合并前应刷新这两个值。旧 G3 acceptance 仍不能覆盖 W4-W6。
 
 ## 4. #77 Beta 合并前顺序
 
 以下工作保持在 #77 分支，完成后它才适合作为 Beta UI foundation 合并：
 
-1. **OPEN - 冻结新基线**：合入本契约文档，把 PR 描述更新到 `c9e1600` 或当时最新 head，列出 Stable/Experimental/Rejected 实际状态和 W4-W6 scope。
+1. **OPEN - 冻结新基线**：合入本契约文档，把 PR 描述更新到 `c89c714` 或当时最新 head，列出 Stable/Experimental/Rejected 实际状态和 W4-W6 scope；当前三份规范文档尚不在 #77 ancestry。
 2. **OPEN - 降级版本承诺**：`BLUE_API_VERSION` 与 host version 改为 `1.0.0-beta.1`；`^1.0.0` 示例、package README、website 和 rc.1 release note不得声称当前已经 Stable 1.0。
 3. **OPEN - 隔离 control plane**：从 plugin-facing root 移除 owner helper；引入 composition authority/lease，禁止 `symbols.original` 成为 sibling 权限升级；aggregate/notification subscription 按 owner capability 窄化。
 4. **OPEN - 收窄公开 vocabulary**：移除 generic `session.act`，隐藏或 authority-gate可直接 inject 的 raw session/projection reader与 requester；保留 negotiated readonly `session.read` seed但不把无 resource/epoch 的形状称为 v1 Stable。当前 flat manifest不能表达 optional，因此 `editor.extensions` 和 `editor.provider` 先退出 public Beta manifest、仅保留 bundle-internal/reference runtime；R2/R3 negotiated optional plane落地后再以 Experimental 公开，不能只改标签继续暴露。
 5. **OPEN - 拆分 notifications**：public consumer 只保留 publish；普通 sibling 不能订阅其他插件通知，owner observe 进入受 authority 保护的 control plane。
 6. **DONE foundation - 保持成熟实现**：canonical UI、panes/overlays、status/status provider、editor extension/provider、split session facade、consumer lifetime fencing、dock/view 删除和 packed examples不回退。后续权限收敛必须保住现有 unit/width/lifecycle 证据。
 7. **OPEN - 修正文档事实**：package README/AGENTS 与 website区分“已实现 Beta”与“已冻结 Stable”；目标能力链接到 contract/roadmap。
-8. **OPEN - 完整 worktree 验收**：在收敛后的 final head重跑全门禁、相关 packed 双线 fixture、`smoke:pty` 和统一专用 profile；profile 穿过 default、120/80/40、pane/overlay、status/editor provider、theme/session swap、editor input/completion/submit 与 unload/reload。用户明确 live-test 验收前不合并 #77。
+8. **PARTIAL - 完整 worktree 验收**：`3f0e42b` 已完成全 package fixture、四条 smoke 与统一专用 profile自动证据；`c89c714` 只新增“examples 不进默认 composition”的 bundle spec，最新 CI/website 已绿。用户仍须在保留的 `blue-ui-api-w4-w6` profile 完成 live-test并明确验收，之前不合并 #77。
 
 ### 当前自动证据
 
-`c9e1600` 的 GitHub CI 与 website check 为 green。W6-4 final-head 报告记录 184 files / 2915 tests passed / 31 个既有条件性 unit skips、per-file 100% coverage、check:lib 87、check:pack 11 tarballs；CI 还执行 frozen install、typecheck、lint、diagrams、build、`check:examples` 和 `smoke:happy`，但不直接执行全部 package fixture 双线。
+`c89c714` 的 GitHub CI 与 website check 为 green：185 files / 2960 tests passed / 31 个既有条件性 unit skips、per-file 100% coverage、check:lib 86、双 Harness 线 examples 8/8 和 `smoke:happy`。直接父提交 `3f0e42b` 的最终候选报告另记录 check:pack 11 tarballs、全部 package fixture双线和三条手工 PTY smoke；`c89c714` 只新增一个默认 composition negative spec，不改变 runtime或 tarball。
 
-Packed evidence 包括 final-head examples 在 Harness `0.1.1-rc.2` / `0.1.1-rc.1` 各 7/7；W6-4 final-head 手工报告中的 `@dsh-blue/blue-app` package fixture 两条 Harness line 各 9/9（其中含 `session.read`、`session.act` 两个专用场景）、context/remote 各 7/7、OpenPencil/Lark 各 9/9，均无 fixture skip/failure且 cleanup 完成。Status provider 13/13、editor extensions 9/9 和 editor provider 11/11 的双线结果分别来自 `b5f3310`、`03cb7e0`、`14cbbb7` checkpoint，权限/稳定性修改后仍须在最终 head重跑。仓内 examples 证明 public tarball/host peer closure 和部分 lifecycle/width，不具备 `form`、required/optional/resource negotiation，也不是独立生态包，不能关闭 v1 三形态或外部消费者门禁。
+Packed evidence 包括 examples 在 Harness `0.1.1-rc.2` / `0.1.1-rc.1` 各 8/8；core 7/7、conversation 11/11、transcript 13/13、interaction 11/11、app 9/9、context/remote 7/7、OpenPencil/Lark 9/9，均在两条 Harness 线无 fixture skip/failure且 cleanup 完成。Status/editor provider 与 editor extensions 已进入最终候选 package fixtures，不再只是 checkpoint 证据。仓内 suite 证明 public tarball/host peer closure 和部分 lifecycle/width，但没有 `form`、required/optional/resource negotiation，也不是独立生态包，不能关闭 v1 三形态或外部消费者门禁。
 
-CI 的 `smoke:happy` 不替代 final-head `smoke:pty`、统一 W4-W6 profile 或人工验收。旧 `blue-ui-g3` 验收早于 W4-W6，不能覆盖其后的全部实现提交，也不能作为当前 head 的 merge acceptance。
+四条 smoke 和统一 W4-W6 profile 的自动 dogfood 已完成：120/80/40、provider/theme/session swap、panes/narrow fallback、overlay、draft、`/new`、`/quit`、terminal mode恢复与无 overflow/crash。它们不替代人工验收；旧 `blue-ui-g3` 验收早于 W4-W6，也不能作为当前 head 的 merge acceptance。
 
 这一步不要求把整个 v1 roadmap 塞回 #77。manifest/schema 和新 ecosystem capability 在 master 上用后续小 PR 收敛，避免 #77 继续膨胀。
 
@@ -120,7 +120,7 @@ Beta merge
   -> theme/settings owners
   -> editor Experimental split + provider namespace
   -> synthetic + ecosystem packed fixtures
-  -> skills + bilingual docs
+  -> skills + 创造模式 authoring pipeline + bilingual docs
   -> 1.0.0 release gate
 ```
 

--- a/docs/blue-pr77-convergence-matrix.md
+++ b/docs/blue-pr77-convergence-matrix.md
@@ -1,139 +1,177 @@
-# PR #77 插件协议收敛矩阵
+# PR #79 设计基线与 PR #77 Beta 合并手册
 
-> 状态：**Active merge control**
-> 基线：`master@1d0f01e`
-> 审计对象：PR [#77](https://github.com/dsh-blue/blue/pull/77) `p2/ui-api-refactor@c89c714`
-> merge-base：`1d0f01e`，PR 分支领先 54 commits
-> 目标规范：[Blue 插件协议 v1 目标态契约](./blue-plugin-contract-v1.md)
+> 状态：**Active merge and delivery control**
+> 设计 PR：[#79](https://github.com/dsh-blue/blue/pull/79)
+> 审计基线：`master@1d0f01e`
+> PR #77 审计对象：`p2/ui-api-refactor@9a6a255`
+> 已验收运行候选：`cf8b3bd`；`9a6a255` 只记录该验收事实
+> 长期 API 语义：[Blue 插件 API v1 设计规范](./blue-plugin-contract-v1.md)
+> PR #77 之后的阶段出口：[Blue 插件 API v1 发布路线](./blue-plugin-api-v1-roadmap.md)
 
-2026-08-29 审计时，#77 的 CI 与 website check 为 green，但 GitHub 状态仍是 `BLOCKED / REVIEW_REQUIRED`；自动检查不替代本矩阵要求的 profile live acceptance。
+本文是从 PR #79、PR #77 到插件协议 `1.0.0` 的执行入口。它负责说明每个 PR 可以发布什么、合并顺序、退出门和证据；API 长期语义只在设计规范定义，阶段产物只在路线图展开。
 
-本文只回答“PR #77 的现有实现如何进入 master，并继续收敛到插件协议 v1”。它不是长期 API 真相。#77 合并并完成 v1 收敛后，本文移入 `docs/history/`。
+PR #77 已吸收 PR #72 的设计输入；PR #72 不再作为独立合并前置项。本手册不得被解释为要求 PR #77 一次实现整个 v1 roadmap。
 
-## 1. 总体判断
+## 1. PR #79 的发布边界
 
-PR #77 已形成六条可保留的实现基座：
+PR #79 是 **docs-only design and control PR**。合并后进入 `master` 的是可公开评审的设计基线，不是可供插件作者依赖的运行时发布。
 
-1. canonical `BlueUiNode`、builders、admission validator 和唯一 pi-tui compiler，legacy frontend renderer 已删除；
-2. managed panes/overlays 与 focus、gesture、abort、buffer/replay；
-3. additive status 和用户选择的 `status.provider`；
-4. revision-fenced editor extension owner、completion/submit/action runtime；
-5. 用户选择的 `editor.provider` shell swap、LKG/breaker/default fallback；
-6. app-owned `session.read/session.act` 分离 facade、legacy dock 删除，以及仓内 public ecosystem packed suite。
+### 1.1 PR #79 合入什么
 
-它尚未形成可直接冻结的 `1.0.0` 插件协议。当前三层状态并不一致：
+- `blue-plugin-contract-v1.md`：Draft 机器/API 目标和七项 Stable 边界；
+- `blue-plugin-host-lifecycle.md`：Draft 内部权限、generation、owner gap 和 restore 规则；
+- 本手册：PR #77 的 Beta 合并步骤与后续独立 PR 队列；
+- `blue-plugin-api-v1-roadmap.md`：Beta 到 Stable 的阶段依赖和发布门；
+- `docs/README.md` 与根 `AGENTS.md`：把当前实现、目标规范和执行文档指向各自权威来源。
 
-| 层 | 数量 | 当前事实 |
-| --- | ---: | --- |
-| manifest vocabulary | 10 | 包含 `session.read/session.act`、`editor.extensions/editor.provider` |
-| public host implemented set | 10 | 十项均有 facade/registry；legacy `dock` runtime 已物理删除 |
-| 默认 bundle advertised owner | 10 | host buffer、core/transcript/interaction/app owner rows 使十项均可协商 |
+这些文档在 GitHub 上公开，但都必须保持 Draft/Active 标记。公开可读不等于公开 API 已发布。
 
-三个数字一致只说明 #77 已把接口接通，不说明接口适合冻结。`session.act` 仍越过目标 v1 的 domain authority 边界；`notifications` 允许普通 consumer 订阅全局通知；editor surfaces 尚未隔离为 Experimental；owner helper 仍可经 `symbols.original` 解包取得；manifest、validator、website 与 public root 继续存在身份、权限和稳定性矛盾。
+### 1.2 PR #79 不发布什么
 
-因此采用两级门禁：
+PR #79 MUST NOT：
 
-- **BETA-MERGE**：阻止 #77 以已知不安全或误称 Stable 的状态进入 master。
-- **V1-RELEASE**：允许 Beta 基础先合并，但在 `BLUE_API_VERSION 1.0.0` 发布前必须完成。
+- 修改 Blue runtime、package manifest、API/host version、schema、generated types、validator、installer、examples 或 bundle composition；
+- 发布 npm package、dist-tag、GitHub Release、协议 tag 或 product/protocol mapping；
+- 把 website 开发手册改写成可运行的 v1 quickstart，或触发“v1 已可用”的 Pages 文案；
+- 修改创造模式 runtime、preset persona 或可执行作者 skill；
+- 宣称七项 capability 已 Stable、PR #77 已满足本手册，或沿用旧 exact head 的真人验收作为 hardening 后验收；
+- 联系生态作者、发布邀请 Issue、提交上游代码 PR 或联系 dsh-market。
 
-裁决含义：
+Website 开发手册、两类 skill 和创造模式持久包属于 PR #77 后的独立交付。它们只能读取已经发布且可执行的 Beta schema/catalog，不能在 PR #79 中预演一份与运行时不一致的契约。
 
-- `KEEP`：实现方向和公共语义可保留；仍需按目标契约补证据。
-- `CHANGE`：保留纵向实现，但修改权限、shape、稳定性或 owner 边界。
-- `REMOVE`：不得进入目标 v1 public surface；兼容代码按依赖顺序删除。
-- `ADD`：PR #77 没有该目标能力或机器契约，需要后续实现。
+### 1.3 PR #79 自身的合并门
 
-## 2. 收敛矩阵
+- `git diff master...<PR79-head>` 只包含 `docs/` 和必要的根 `AGENTS.md` 权威指针；
+- 设计规范、Host 生命周期、本手册和路线图互相引用，且不重复声明冲突的 API 语义；
+- Stable catalog 只出现七项既定能力，manifest 无 runtime `form`；
+- PR #77 的 Beta 门与 v1 Stable 门明确分开；
+- PR #79 合并说明写明：**no runtime release, no npm release, no website/API availability claim**。
 
-| Surface | #77 当前状态 | 裁决 | v1 目标 | Owner | Gate / 必需证据 |
-| --- | --- | --- | --- | --- | --- |
-| `BlueUiNode` wire | `packages/api/src/contracts.ts` 中闭合 union；纯 clone/freeze；callback 与 signal 仍为 process-local | KEEP | renderer-neutral canonical tree；文档明确“数据可检查”不等于整个 contribution 可跨进程序列化 | api owns wire | V1：hostile realm/getter/cycle/depth/node/collection corpus；外部 tarball consumer |
-| `@dsh-blue/blue-ui` builders | 纯 builder、caller-safe，官方 panel/dialog/status 已消费 | KEEP | 只做 ergonomics，不另立 wire truth；输出必须通过同一 validator | ui package | V1：builder/wire/API declaration diff；至少两个外部插件共用 |
-| core validator/compiler | core 是唯一 admission/compiler 和 pi-tui boundary；已有 exhaustive/width tests；`082c801` 已删除 legacy frontend renderer | KEEP | 非 core 包不接触 pi-tui、ANSI、terminal width/focus；compiler failure 隔离 contribution | core | V1：2..120 width/hostile node；public kit packed import；禁止恢复第二 renderer path |
-| `panes` | host registry、每插件配额、buffer/replay、surface bridge、semantic events、responsive layout已实现；仓内 packed examples 覆盖 header/right/bottom、20/40/80/120、absent/admission/unload | KEEP | Stable managed surface；明确 renderer owner 暂未 attach 时的 retained queue/replay | core surface owner | V1：在真实 surface manager 补 narrow、owner reload、focus restore、late event；独立生态 packed consumer |
-| `overlays` | one-shot gesture、capturing 配额、FIFO/latest-wins、abort/close/focus restore 已实现；仓内 packed example 覆盖 atomic capability rejection、gesture、unload/late use | KEEP | Stable managed overlay；普通插件不能主动开 capturing overlay | core overlay owner | V1：真实 renderer 的 focus/timeout/double submit/owner swap、hostile sibling；独立生态 packed consumer |
-| additive `status` | narrow recursive status node、独立 revision、transcript owner/compiler 已实现 | KEEP | Stable additive status；非交互、不能夺取 footer composition | transcript status owner | V1：external status packed fixture、width、render throw、unload/reload |
-| `status.provider` | inert candidates、settings selection、actual-width dry render、same-session LKG、cross-session default、3/60s breaker、fallback 已实现；最终候选的 transcript packed fixture 在双 Harness 线各 13/13，覆盖 selection、refresh、inert、fallback、owner unload/reload 与 late handle | CHANGE | 保留 provider 事务；专用 snapshot 不隐式带 session id/cwd/model；需要时显式申请 `session.read` resource；加入 session epoch/revision | transcript composition + settings | V1：snapshot/resource 收窄、theme/session switch、stale generation、failure attribution与 dsh-status-bar 外部 slice；真实 profile swap 的自动证据已完成，真人验收仍 pending |
-| `commands` | interaction bridge 映射到 Harness commands，具备 AbortSignal、owner-minted gesture、duplicate rollback、unload | KEEP | 只承诺 Blue-local UI command；能直接注册 Harness command 的 domain 插件继续走 host service | interaction owner | V1：packed command、late settlement/unload、gesture chain；文档避免双 command discovery |
-| `notifications` | 一个 capability 同时返回 publish/subscribe；任一普通 consumer 可收到其他插件 publish 的全局通知，owner bridge 另有 observer | CHANGE | public 只保留 `notifications.publish`；observe 属 owner control plane；定义 dedupe/replace/duration/priority 和动态 rate limit | notification model + interaction renderer | **BETA-MERGE blocker**：无条件移除普通 consumer subscribe并将 owner observe收回受 authority 保护的 control plane，不能靠降为 Experimental 保留越权观察。V1：publisher 隔离、sink absent、rate/dedupe、unload/late publish |
-| `editor.extensions` | 已有真实 owner：passive node/action、`/ @ #` completion、submit transform、revision/abort/unload；最终候选的 interaction packed fixture 在双 Harness 线各 11/11，含 extension owner replay/inert 与 callback abort/unload/late rejection；当前不提供 draft read/write | KEEP + CHANGE | Beta 保留纵向实现；v1 将现有 decorations/completions/submit.transform 拆权，并另增 draft.read/write，均为 Experimental/optional | interaction editor owner | BETA-MERGE：不得称 Stable；`before/after` 静态 `BlueUiNode` 与 runtime passive subset 收窄一致。V1：逐项最小授权；真实 editor input/completion apply/submit；draft/history/IME 不丢 |
-| `editor.provider` | 已有真实 owner、persisted user selection、actual-width dry render、同一 editor/focus 上的原子 shell swap、LKG/breaker/default fallback、abort/stale/unload；最终候选的 interaction 11/11 双线 fixture 覆盖 selection/identity/fallback/inert、owner unload/replay、event abort/late；public type仍只有 `render/onEvent`，未冻结 activate/dispose 或无状态 shell lifecycle语义 | KEEP + CHANGE | 作为 Experimental optional 的 host-owned editor shell provider；恰好一个 `editor-control`，不授予 draft/cursor/history/IME/raw-key 或 engine ownership；mode 另走 `session.read` grant | interaction owner + core compiler | BETA-MERGE：flat manifest阶段退出 public Stable surface、保留 internal/reference runtime。Experimental 发布：optional schema/subpath、public lifecycle与真人统一 profile验收。未来 Stable：独立生态 provider等完整门禁 |
-| flat `capabilities[]` | required/optional、capability version、resource grant、form 均不可表达；`open()` all-or-nothing | CHANGE | 对象式 required/optional request；每项 `{name, version, resources?}`；返回 negotiated grants | api/schema + host | V1：positive/negative schema corpus；required fail、optional degrade、resource subset/denial、duplicate cross-group |
-| manifest identity | 已有 `package.json.blue.manifest` pointer、root JSON、quickstart 和八包 example suite（user kit、六个 runnable plugins、composition）；但 validator 仍硬找 root JSON，`entry` 写内部 `./lib/index.js`，源码在 `open()` 旁再手写 manifest，并要求 entry `name`=package | CHANGE | `package.json.blue.manifest` 唯一发现入口；id=package name；entry=exports subpath；Cordis name/row id 独立 | schema + installer | V1：packed package、exports/files、runtime import 同一 JSON、identity negative corpus |
-| `integrity` author field | manifest 接受作者提供的 tarball digest | REMOVE | integrity/source commit 放 installer receipt/lock，不能由被验证包自证 | installer | V1：安装 receipt 和 source pin fixture；schema 拒绝 author integrity |
-| semver admission | manifest 用字符正则；host 只用 `/^\^?1/` 近似 API major | CHANGE | 真实 semver range parse/intersection；API、product、Harness、Node、capability version 分离 | schema/runtime admission | V1：prerelease、union、upper bound、invalid range corpus |
-| `session.read` | `f375c13` 已拆出纯 readonly `current/subscribe` facade、真实 app owner、monotonic revision、clone/freeze、replay/owner-gap fencing；但完整 `blueSessionReader` 仍是任意 sibling可 inject 的 Cordis service，可绕过 fields grant | CHANGE | 保留 readonly seed，按 identity/cwd/status/mode/model resource 裁剪，并加入明确 `sessionEpoch`；raw source只对 authority owner可见 | app + narrow harness adapter | **BETA-MERGE blocker**：隐藏/authority-gate raw reader并加 hostile direct-inject fixture。V1：same-id new epoch、session switch、headless absence、bounded snapshot、resource denial、no Agent/Session/write leakage |
-| `session.act` | `f375c13` 已实现独立 requester、followup/steer/interrupt、host-wide FIFO、abort、session/owner/consumer/unload stale fencing和双 Harness 线 packed fixture；完整 `blueSessionRequester` 仍可被任意 sibling inject，same-id 仍只按 id 判断且无 gesture/resource policy | REMOVE | v1 无通用 session write；app内部 dispatcher不作为 plugin-facing service，业务写按真实 action 或 `conversation.itemActions` 扩展点设计 | domain plugin owns action | **BETA-MERGE blocker**：移出公开 vocabulary并隐藏/authority-gate raw requester，hostile sibling direct inject必须失败。V1：negative schema/API fixture |
-| owner helper root exports | api root 仍导出 attach/snapshot/subscribe/mint/close；guarded proxy 直接调用现已拒绝，但官方 bridge 继续用 Cordis `symbols.original` 解包，普通 sibling 可复制该路径 | CHANGE | public host 只有 version/open/data facets；control plane 要求 bundle composition 创建的 authority/lease，普通 sibling 无法获得 | bundle + api host | **BETA-MERGE blocker**：hostile sibling 证明 unwrap/self-attach/snapshot/mint/close 均失败；官方 owner reload 保持正常 |
-| aggregate owner snapshot | 一个 snapshot 同时含全部 capability contribution 与 revisions | CHANGE | owner subscription 按 capability/lease 窄化；owner 不能观察无关插件数据 | capability owners | BETA-MERGE：至少隔离公共 root。V1：per-owner subscription 和 cross-capability negative fixture |
-| `BluePluginDefinition.apply(api: unknown)` | public type 无 loader/runtime consumer | REMOVE | v1 使用真实 Cordis entry + parsed manifest + negotiated typed API；不保留占位符 | api/loader | BETA-MERGE 或首个 schema PR 删除；compile negative fixture |
-| error taxonomy | stale/timeout/unavailable/resource denial 不可区分，多处压入 `BLUE_ACTION_REJECTED/ABORTED` | CHANGE | 采用目标契约的 negotiation/admission/execution 错误分类；无异常跨边界 | api | V1：每个 code 有可复现 fixture，message 不承担机器语义 |
-| legacy `dock` | `bbbe6b1` 已物理删除 type、registry、host aggregate、transcript bridge和 bundle consumer；validator 只保留 actionable migration diagnostic | REMOVE (CLOSED) | 保持 runtime 无 dock；旧 manifest 只返回明确迁移诊断 | transcript/core panes | Beta 代码门已关闭。V1：schema negative corpus 与 `rg` drift guard 防止兼容路径回流 |
-| legacy `panels/editor/tools` | migration validator 仍识别这些旧名字；无 v1 owner/API | REMOVE | 不进入新 schema、catalog 或 API root；validator 只返回明确迁移诊断 | schema/validator | V1：negative corpus；网站不再把旧名字描述为 future capability |
-| `projections.read` | `blueSessionProjections` app reader可按任意字符串返回 `unknown`，且仍是任意 sibling可 inject 的 Cordis service，没有 public resource gate | ADD | raw source只对 authority owner可见；manifest 精确 key allowlist；一致 cut、size bound、epoch/asOfSeq、key unload 语义 | app/harness adapter | **BETA-MERGE blocker**：隐藏/authority-gate raw projection reader并加 hostile direct-inject fixture。V1：dsh-context + Cost Meter，replay/resume、duplicate/older seq、key unload、late callback |
-| conversation APIs | conversation projection存在，但无 public bounded reader、navigate 或 item action registry | ADD | `conversation.read/navigate/itemActions`；item action 只调度，业务执行留在插件 service | conversation + transcript/interaction | V1：Navigator、Rewind、Message Edit、Bookmark/Tag reference；pagination/stale/gesture/unload |
-| `theme.provider` | frontend theme model存在；公开插件没有 provider negotiation/selection contract | ADD | semantic token candidate、用户选择、validation、fallback；无 ANSI/CSS | frontend/core composition | V1：Catppuccin，token completeness、swap failure、unload、narrow/width |
-| `settings.sections` | Blue 有内部 settings panel 和 dsh-settings owner；无第三方 section contract | ADD | 只贡献 settings UI；plugin config/schema/persistence 直接 inject `dsh-settings` | interaction settings UI | V1：Catppuccin + Lark，read-only backend、conflict、unload；证明无 Blue storage |
-| JSON Schema / TS manifest | 没有独立 schema；script 只检查字段存在且不复用 runtime validator | ADD | Draft 2020-12 schema 为源，生成 TS type；Ajv/validator/installer/runtime 共用；drift gate | api/schema | V1：schema corpus、generated diff、published URL/subpath、真实 tarball |
-| public API plane | owner helpers、Stable/Experimental、plugin-facing types混在 root | CHANGE | root 只导出 Stable；Experimental 走明确 subpath/标记；owner authority 不可由普通插件取得 | api package | BETA-MERGE：稳定性声明收窄。V1：API declaration report、exports/files/tsdown triangle |
-| docs/skills/创造模式 | website/README 与两组 skills 把 flat manifest、`session.act`、notification subscribe、旧 identity 和 editor surfaces描述成 Stable 1.0。创造模式已有 isolate、真实 `cordis_define/run/update/stop/rollback` 与 durable-buffer e2e，但只检查 skill discovery，不执行 bundled skills，也不生成、validate 或 packed-install 持久包；仓内 fixture还拒绝 workspace 外包 | CHANGE | contract 是目标真相；能力表、模板与 transient request从 schema/catalog 生成；创造模式成为可生成三种 form、识别 zero-API并验证持久包的 official consumer；中英同步 | bundle preset + authoring toolkit + docs | **BETA-MERGE blocker**：按 Stable/Experimental/Rejected 重写，不把“已实现”当“已冻结”。V1：四类 skill eval、外部可调用 validator/fixture、完整 prototype -> confirm -> package -> 双线 packed e2e |
-| `BLUE_API_VERSION` | root与host仍声明 `1.0.0`；examples、README、website 和 rc.1 release note均按 `^1.0.0`/Stable 推广 | CHANGE | #77 只作为 `1.0.0-beta.1` 合并；全部 V1 gate 通过后一次性升 `1.0.0` | api/release | **BETA-MERGE blocker**：不产生错误稳定承诺；V1 release report |
+满足这些条件后可以合并 PR #79。合并动作不需要插件 runtime dogfood，因为它不改变用户可见行为；文档检查和 review 仍必须通过。
 
-## 3. 相关 PR 处置
+## 2. PR #77 当前判断
 
-- PR [#72](https://github.com/dsh-blue/blue/pull/72) 与 #77 修改同一 UI 蓝图和索引，但保留了更旧的 API version、overlay/event 和实施裁决。它不能再单独合并；按 #77 当前 merge gate，在 #77 真人验收并合并后关闭为 superseded。
-- PR [#76](https://github.com/dsh-blue/blue/pull/76) 文件上可独立处理，但 capability 调研仍基于旧四能力和 `dock`。若合并，MUST 标成带日期的需求快照或先按 #77 更新；它不是规范来源。
-- `docs/blue-ui-component-enhancement.md` 已更新为 W1-W6 最终候选账目，并明确真人验收、合并和候选发布未发生；该陈旧事实项已关闭。待本矩阵接管进度且真人验收完成后，再单独归档。
-- #77 的 PR body 已更新 W1-W6 scope、自动门禁与仍缺的真人验收，但 `Final candidate head: 3f0e42b` / 2959 tests 落后最新 `c89c714` / 2960 tests 一次只增加 bundle composition guard 的提交；合并前应刷新这两个值。旧 G3 acceptance 仍不能覆盖 W4-W6。
+PR #77 已形成可保留的 implementation baseline：canonical UI/compiler、managed panes/overlays、additive status、status/editor provider runtime、editor extension runtime、split session facade、consumer lifetime fencing、legacy dock/view renderer 删除，以及独立 packed example suite。
 
-## 4. #77 Beta 合并前顺序
+`cf8b3bd` 已完成 current/previous Harness fixtures、四条 smoke、两个专用 profile 自动 dogfood和用户 live acceptance；`9a6a255` 只把该事实写回文档。这证明 W1-W6 候选可用，但不自动证明当前 public API 适合标 Stable。
 
-以下工作保持在 #77 分支，完成后它才适合作为 Beta UI foundation 合并：
+合并前仍有五项安全或承诺问题：
 
-1. **OPEN - 冻结新基线**：合入本契约文档，把 PR 描述更新到 `c89c714` 或当时最新 head，列出 Stable/Experimental/Rejected 实际状态和 W4-W6 scope；当前三份规范文档尚不在 #77 ancestry。
-2. **OPEN - 降级版本承诺**：`BLUE_API_VERSION` 与 host version 改为 `1.0.0-beta.1`；`^1.0.0` 示例、package README、website 和 rc.1 release note不得声称当前已经 Stable 1.0。
-3. **OPEN - 隔离 control plane**：从 plugin-facing root 移除 owner helper；引入 composition authority/lease，禁止 `symbols.original` 成为 sibling 权限升级；aggregate/notification subscription 按 owner capability 窄化。
-4. **OPEN - 收窄公开 vocabulary**：移除 generic `session.act`，隐藏或 authority-gate可直接 inject 的 raw session/projection reader与 requester；保留 negotiated readonly `session.read` seed但不把无 resource/epoch 的形状称为 v1 Stable。当前 flat manifest不能表达 optional，因此 `editor.extensions` 和 `editor.provider` 先退出 public Beta manifest、仅保留 bundle-internal/reference runtime；R2/R3 negotiated optional plane落地后再以 Experimental 公开，不能只改标签继续暴露。
-5. **OPEN - 拆分 notifications**：public consumer 只保留 publish；普通 sibling 不能订阅其他插件通知，owner observe 进入受 authority 保护的 control plane。
-6. **DONE foundation - 保持成熟实现**：canonical UI、panes/overlays、status/status provider、editor extension/provider、split session facade、consumer lifetime fencing、dock/view 删除和 packed examples不回退。后续权限收敛必须保住现有 unit/width/lifecycle 证据。
-7. **OPEN - 修正文档事实**：package README/AGENTS 与 website区分“已实现 Beta”与“已冻结 Stable”；目标能力链接到 contract/roadmap。
-8. **PARTIAL - 完整 worktree 验收**：`3f0e42b` 已完成全 package fixture、四条 smoke 与统一专用 profile自动证据；`c89c714` 只新增“examples 不进默认 composition”的 bundle spec，最新 CI/website 已绿。用户仍须在保留的 `blue-ui-api-w4-w6` profile 完成 live-test并明确验收，之前不合并 #77。
+1. API/host 宣称 `1.0.0`，但 schema、资源协商和生态证据尚未完成；
+2. generic `session.act` 越过领域 action ownership；
+3. 普通消费方可以订阅其他插件的全局通知；
+4. owner helper 和 raw session/projection backing service 存在 sibling 绕过授权的路径；
+5. editor/provider surface 被写成 Stable，而目标 v1 只冻结七项最小能力。
 
-### 当前自动证据
+因此必须区分：
 
-`c89c714` 的 GitHub CI 与 website check 为 green：185 files / 2960 tests passed / 31 个既有条件性 unit skips、per-file 100% coverage、check:lib 86、双 Harness 线 examples 8/8 和 `smoke:happy`。直接父提交 `3f0e42b` 的最终候选报告另记录 check:pack 11 tarballs、全部 package fixture双线和三条手工 PTY smoke；`c89c714` 只新增一个默认 composition negative spec，不改变 runtime或 tarball。
+- **BETA-MERGE**：PR #77 阻止已知越权和错误 Stable 承诺进入 `master`；
+- **PUBLIC-BETA**：版本化 schema/catalog/validator、product/protocol mapping 和至少一项外部可安装 capability 已实际发布；它不表示完整作者手册、skill 或 Stable 证据已经完成；
+- **V1-RELEASE**：真实插件证据和所有发布门关闭后才发布协议 `1.0.0`。
 
-Packed evidence 包括 examples 在 Harness `0.1.1-rc.2` / `0.1.1-rc.1` 各 8/8；core 7/7、conversation 11/11、transcript 13/13、interaction 11/11、app 9/9、context/remote 7/7、OpenPencil/Lark 9/9，均在两条 Harness 线无 fixture skip/failure且 cleanup 完成。Status/editor provider 与 editor extensions 已进入最终候选 package fixtures，不再只是 checkpoint 证据。仓内 suite 证明 public tarball/host peer closure 和部分 lifecycle/width，但没有 `form`、required/optional/resource negotiation，也不是独立生态包，不能关闭 v1 三形态或外部消费者门禁。
+## 3. Surface 裁决
 
-四条 smoke 和统一 W4-W6 profile 的自动 dogfood 已完成：120/80/40、provider/theme/session swap、panes/narrow fallback、overlay、draft、`/new`、`/quit`、terminal mode恢复与无 overflow/crash。它们不替代人工验收；旧 `blue-ui-g3` 验收早于 W4-W6，也不能作为当前 head 的 merge acceptance。
+| Surface | #77 当前事实 | 裁决 | Beta 合并要求 | v1 后续 |
+| --- | --- | --- | --- | --- |
+| canonical UI/compiler | `BlueUiNode`、builder、validator 和唯一 pi-tui compiler 已运行 | KEEP | 不恢复 legacy renderer；失败隔离 contribution | hostile node、2..120 width、public packed kit |
+| `commands` | 真实 interaction bridge、abort、gesture、duplicate rollback、unload | KEEP | 标 Beta，保住生命周期证据 | negotiation、resource/limits、真实插件 consumer |
+| `status` | additive node、revision、真实 owner/compiler | KEEP | 标 Beta；不能接管整个 footer | width/render failure/unload、真实插件 consumer |
+| `panes` | managed placement、responsive layout、buffer/reload | KEEP | 使用 `panes`；保留最新注册，事件与 gesture 不排队 | narrow/focus/owner reload、真实插件 consumer |
+| `overlays` | gesture、capturing quota、abort/close/focus restore | KEEP | overlay/gesture 不跨 owner 重载 replay | timeout/double-submit/hostile sibling |
+| `notifications` | publish 与 subscribe 混在一个 consumer capability | CHANGE | public 只保留 `notifications.publish`；observe 仅供官方 owner | rate/dedupe/sink absence/unload |
+| `session.read` | readonly current/subscribe seed，但 raw reader 可被 sibling inject | CHANGE | 保留 Beta seed；隐藏或保护 raw backing service，不宣称资源/epoch 已 Stable | fields grant、sessionEpoch、same-id new epoch |
+| projection reader | 可按任意 key 读 `unknown`，raw service 可被 sibling inject | CHANGE | backing service 只供官方 owner；当前 public 形状不标 Stable | `session.projections.read` 精确 key grant、一致 cut、size bound |
+| `session.act` | followup/steer/interrupt requester 与 fencing 已实现 | REMOVE public | 从 manifest、public root、README 和 website 移除；内部 dispatcher 可保留 | 领域写入继续走真实 action，不建立 generic replacement |
+| status/editor provider | provider swap、LKG、breaker、fallback 已有完整 runtime | DEFER public | 只保留 bundle-internal/reference runtime，或明确 Experimental；不得占 Stable root | 真实消费者共创后另走 1.x 提案 |
+| editor extensions | completion/submit/action、abort/stale/unload 已实现 | DEFER public | 只保留 bundle-internal/reference runtime，或明确 Experimental | 按最小授权拆分后另走 1.x 提案 |
+| owner/control operations | root helper、aggregate/observe、gesture/close 存在绕过风险 | CHANGE | 普通 sibling 无支持路径可 self-attach、读取 aggregate、observe、mint 或 close | 具体 authority/generation 机制在内部规范与后续 PR 冻结 |
+| manifest/docs/skills | flat capability list、inline manifest 和 Stable 1.0 表述 | CHANGE | 标 `1.0.0-beta.1`，删除错误稳定承诺和旧 capability 示例 | 单一 schema/catalog、required/optional/resources、持久包管线 |
 
-这一步不要求把整个 v1 roadmap 塞回 #77。manifest/schema 和新 ecosystem capability 在 master 上用后续小 PR 收敛，避免 #77 继续膨胀。
+## 4. PR #77 合并 runbook
 
-## 5. v1 收敛依赖顺序
+### 4.1 同步设计基线
 
-```text
-Beta merge
-  -> JSON Schema + identity + semver + generated manifest type
-  -> negotiated grants + public/control plane + error taxonomy
-  -> existing UI surface cleanup (notifications split, status snapshot; dock 已完成)
-  -> session.read resource/epoch + projection/conversation owners
-  -> theme/settings owners
-  -> editor Experimental split + provider namespace
-  -> synthetic + ecosystem packed fixtures
-  -> skills + 创造模式 authoring pipeline + bilingual docs
-  -> 1.0.0 release gate
-```
+1. 合并 PR #79，记录其 merge commit。
+2. 将 PR #77 更新到包含该 merge commit 的最新 `master`；rebase 或 merge 均可，但 PR body 必须记录新的 base 和 exact head。
+3. 用本手册重新核对 PR #77 的 public exports、manifest、README、website、examples、release note 和 skills，不得只修改版本常量。
+4. 保留 `cf8b3bd` 的 W1-W6 证据作为基线，不把它登记成新 head 的最终验收。
 
-每一行关闭时必须把“当前实现、测试证据、owner、bundle row、fixture report”填回矩阵，不能只把状态改成 Done。
+### 4.2 实施最小 Beta 安全门
 
-## 6. 归档条件
+PR #77 分支在合并前只完成以下工作：
 
-满足以下条件后，本矩阵移动到 `docs/history/blue-pr77-convergence-matrix.md`：
+1. 将 API/host version 改为 `1.0.0-beta.1`，同步 PR #77 自己涉及的 README、website、examples、release note 和 skills 的稳定性表述。
+2. 从 public vocabulary 和 manifest 移除 generic `session.act`；内部 app dispatcher 不作为普通 Cordis service 暴露。
+3. 将 notification consumer API 收窄为 publish-only；普通 sibling 不能观察其他插件通知。
+4. 从 plugin-facing root 移除 owner attach、aggregate snapshot/observe、gesture mint 和 semantic close helper。
+5. 隐藏或保护 raw session/projection reader/requester；普通 sibling 只能取得协商后的裁剪 facade。
+6. 将 editor extension/provider 和 status provider 退出 Stable root，保留其成熟 runtime 与 reference tests。
+7. 保持 canonical compiler、panes/overlays、additive status、provider/editor runtime、lifetime fencing 和 packed examples 不回退。
 
-- #77 已按 Beta 规则合并；
-- 所有 BETA-MERGE 行关闭；
-- 所有 Stable v1 capability 通过 conformance；
-- `BLUE_API_VERSION` 已发布为 `1.0.0`；
-- 长期行为可完全由目标契约、生成 schema/API reference 和 package AGENTS 解释。
+这里冻结的是可观察权限边界，不要求 PR #77 先实现名为 authority lease 的特定数据结构。内部实现可以使用 capability-scoped token、私有 closure 或 bundle-owned owner handle，只要满足 [Host 生命周期规范](./blue-plugin-host-lifecycle.md) 的行为和 hostile-sibling 证据。
 
-归档时记录最终 merge commit、协议发布 tag、fixture exact Harness lines、profile dogfood 和人工验收结论。
+### 4.3 形成新 exact head 的自动证据
+
+Beta hardening 形成新的 exact runtime head 后必须：
+
+- hostile sibling 无法 self-attach、读取 aggregate、observe 全局通知、mint gesture、关闭别人的 overlay或直接取得 raw session/projection truth；
+- owner 短暂 reload 后 `commands`/`status`/`panes` 只恢复最新注册，overlay/gesture/action/notification/旧 callback 不 replay；
+- unit、compile、coverage、typecheck、lint、build、check:lib、check:pack、examples、diagrams 和 website build 全绿；
+- current/previous Harness packed fixture 的 declared scenarios 全执行且无 skip/failure；
+- `smoke:happy`、必要的 PTY smoke 和 worktree profile 覆盖 120/80/40、pane/overlay、provider/editor reference runtime、theme/session swap、input/completion/submit；
+- PR body 或 acceptance record 写明 exact commit、Blue API Beta version、两条 Harness line、profile、执行命令、fallback、unload/reload 和失败项。
+
+### 4.4 真人验收、合并与清理
+
+1. 用 PR #77 worktree 对应的 `blue-<tag>` profile 提示用户 live-test；不能指向共享生产 `blue` profile。
+2. 等待用户对 **新的 exact head** 明确回复“验收通过”；自动测试不能替代这一步。
+3. 验收后才合并 PR #77；合并说明必须写明这是 Beta foundation，不是 protocol v1 release。
+4. 在主 checkout 重建合并后的 `lib/`，记录 merge commit 和 dogfood 结果。
+5. 只有合并完成后才删除 `blue-<tag>` profile 和 worktree。
+6. 不在该合并动作中发布 `1.0.0`、npm Stable tag 或正式插件开发手册。
+
+## 5. Review PR #77 时如何理解内部术语
+
+- **control-plane authority**：Blue 官方 owner 用来接管 capability、读取完整注册表、创建 gesture 或执行关闭等管理动作的内部权限。普通插件只能获得自己获准的数据和注册接口。
+- **owner generation**：某个官方 owner 每次成功挂载的实例代号。owner 重载会产生新 generation，旧 handle 和旧异步结果必须失效。
+- **owner gap**：capability 已由当前 composition 安装并允许使用，但负责消费它的 UI owner 尚未启动、正在重载或暂时失败。
+- **registration restore**：gap 期间只保留普通插件“当前最新的定义”，新 owner 恢复后重新挂载这些定义。
+- **replay**：把 gap 中发生的动作、通知、overlay、gesture 或旧回调补执行。此行为被禁止。
+
+验收时只判断外部结果：`commands`、`status`、`panes` 的最新定义可以恢复；操作、通知、overlay、gesture 和旧结果绝不补执行。实现是否真的有一个叫 `authority lease` 的类型不是合并条件。
+
+## 6. PR #77 之后的独立 PR 队列
+
+后续工作必须在 `master` 上从 PR #77 的 merge commit 起步。每个编号表示交付批次，不预占实际 GitHub PR 号；同一批次内仍应按 capability 或工具边界拆小 PR。
+
+| 批次 | 依赖 | 独立 PR 范围 | 退出门 | 此时仍不能宣称 |
+| --- | --- | --- | --- | --- |
+| P1 机器契约 | PR #77 merged | JSON Schema 2020-12、generated manifest type、semantic validator、immutable schema export、product/protocol mapping | positive/negative corpus；schema/runtime/CLI 同结论；packed files/exports 可见 | public Beta 可开发、任何 capability Stable |
+| P2 Host 协商与权限 | P1 | required/optional/resource admission、exact grants、error taxonomy、受保护 control plane、generation/owner-gap 行为 | hostile sibling、partial grant、owner reload、declaration report 全绿 | 七项 capability 已有真实生态证据 |
+| P3 UI capability Beta | P2 | 原则上分别收敛 `commands`、`status`、`panes`、`overlays`、`notifications.publish`；每个 PR 同步 owner、fallback、limits、fixture 和 reference | 每项独立 packed fixture、unload/reload、width/abort/stale 按适用场景全绿 | capability Stable；provider/editor 自动进入 v1 |
+| P4 Session data Beta | P2 | `session.read` 与 `session.projections.read` 分开实施 fields/key grant、epoch/seq、一致 cut 和 size bound | same-id new epoch、replay/resume、key unload、stale/late result 全绿 | generic `session.act` 或 raw Session 可用 |
+| P5 作者工具与文档 | P1/P2 完成，至少一个 P3/P4 capability 可运行 | 作者 `blue-plugin-development` skill、创造模式 prototype-to-local-package、任务式中英文 Website 开发手册、公开 validator/conformance 命令 | skill eval、教程 packed fixture、双语/链接/catalog drift、真实 profile 全绿 | protocol Stable；自动获准 GitHub/npm 发布 |
+| P6 生态验证 | 对应 P3/P4 capability 可运行 | 六个首批项目各用独立 worktree/PR 或固定 conformance patch；维护者 outreach skill 可在本批次加入 | 固定 upstream commit、公开 Service/projection 边界、packed current/previous Harness、相同邀请标准 | 作者认可等于 conformance；已获得提交上游代码 PR 的授权 |
+| P7 Stable 晋升 | P3-P6 对应证据完成 | 每项 capability 单独从 Beta 晋升 Stable；API root/declaration/docs/catalog 同步 | 真实 owner、官方/reference consumer、真实 Harness plugin、fallback、无 skip/failure、真人验收 | 其他 capability 同时 Stable |
+| P8 dsh-market Beta 合作 | public Beta + 作者 skill + 至少两个 runnable integrations | metadata/spec 对齐、Blue-compatible 标识、profile 安装路径、双方文档互荐 | 合作范围有双方确认；不调用 private Web route | Blue 接管 market install/update，或合作本身关闭 v1 技术门 |
+| P9 v1 发布 | 七项 P7 完成，P5/P6 总门关闭 | protocol `1.0.0`、对应 Blue `0.x`、创造模式、schema/API/mapping/migration notes 和干净安装验证 | 路线图 R6 全部门禁、最终 live acceptance、registry clean-profile smoke | 合并 commit 本身等于已发布 artifact |
+
+并行规则：P3 的各 UI capability、P4 的两个 session capability、P5 的文档/skill/创造模式和 P6 的生态项目可以在依赖满足后并行；同一 PR 不得同时发明机器契约、扩 Stable catalog、迁移多个生态项目并发布 release。
+
+## 7. 每个后续 PR 的共同模板
+
+每个独立 PR 必须在 PR body 或对应 acceptance record 中写明：
+
+- **Scope**：本 PR 唯一负责的 capability、工具或文档交付；
+- **Authority**：消费方能做什么、官方 owner 才能做什么；
+- **Fallback**：capability absent、owner gap、单 contribution 失败时的结果；
+- **Lifecycle**：consumer unload、owner reload、session epoch、abort 和 late result；
+- **Artifacts**：schema/API/package/website/skill 中实际发生变化的部分；
+- **Evidence**：exact commit、tarball digest、Blue product/protocol/Harness versions、declared/executed/skipped/failures、profile 和人工验收；
+- **Release claim**：只允许声称本 PR 真实关闭的 Beta/Stable/Release 状态。
+
+状态必须依次记录为 `implemented -> automated green -> live accepted -> merged -> artifact published`。不得用前一个状态代替后一个状态，也不得把生态作者是否回复混入技术 conformance。
+
+## 8. 归档条件
+
+PR #77 合并后，本手册继续作为 P1-P9 的执行入口，并更新 PR #77 final merge commit。协议 `1.0.0` 和对应 artifacts 实际发布后，才把本手册移入 `docs/history/`；归档必须记录协议 tag、Blue product version、Harness lines、schema/API URL、最终 profile 和人工验收。

--- a/docs/blue-pr77-convergence-matrix.md
+++ b/docs/blue-pr77-convergence-matrix.md
@@ -2,8 +2,8 @@
 
 > 状态：**Active merge control**
 > 基线：`master@1d0f01e`
-> 审计对象：PR [#77](https://github.com/dsh-blue/blue/pull/77) `p2/ui-api-refactor@03cb7e0`
-> merge-base：`1d0f01e`，PR 分支领先 33 commits
+> 审计对象：PR [#77](https://github.com/dsh-blue/blue/pull/77) `p2/ui-api-refactor@c9e1600`
+> merge-base：`1d0f01e`，PR 分支领先 48 commits
 > 目标规范：[Blue 插件协议 v1 目标态契约](./blue-plugin-contract-v1.md)
 
 2026-08-29 审计时，#77 的 CI 与 website check 为 green，但 GitHub 状态仍是 `BLOCKED / REVIEW_REQUIRED`；自动检查不替代本矩阵要求的 profile live acceptance。
@@ -12,22 +12,24 @@
 
 ## 1. 总体判断
 
-PR #77 已形成四条可保留的纵向切片：
+PR #77 已形成六条可保留的实现基座：
 
-1. canonical `BlueUiNode`、builders、admission validator 和唯一 pi-tui compiler；
+1. canonical `BlueUiNode`、builders、admission validator 和唯一 pi-tui compiler，legacy frontend renderer 已删除；
 2. managed panes/overlays 与 focus、gesture、abort、buffer/replay；
 3. additive status 和用户选择的 `status.provider`；
-4. revision-fenced editor extension owner、completion/submit/action runtime 和 packed fixture。
+4. revision-fenced editor extension owner、completion/submit/action runtime；
+5. 用户选择的 `editor.provider` shell swap、LKG/breaker/default fallback；
+6. app-owned `session.read/session.act` 分离 facade、legacy dock 删除，以及仓内 public ecosystem packed suite。
 
 它尚未形成可直接冻结的 `1.0.0` 插件协议。当前三层状态并不一致：
 
 | 层 | 数量 | 当前事实 |
 | --- | ---: | --- |
 | manifest vocabulary | 10 | 包含 `session.read/session.act`、`editor.extensions/editor.provider` |
-| public host implemented set | 8 | 不含两个 session capability；另有内部 legacy `dock` |
-| 默认 bundle active owner | 7 | commands、status、notifications、panes、overlays、editor.extensions、status.provider；另有 legacy dock owner |
+| public host implemented set | 10 | 十项均有 facade/registry；legacy `dock` runtime 已物理删除 |
+| 默认 bundle advertised owner | 10 | host buffer、core/transcript/interaction/app owner rows 使十项均可协商 |
 
-`editor.provider` 只有 type/registry，没有 selection/swap owner；`session.read/session.act` 仍明确拒绝。manifest、validator、website 与 public root 还存在身份、权限和稳定性矛盾。
+三个数字一致只说明 #77 已把接口接通，不说明接口适合冻结。`session.act` 仍越过目标 v1 的 domain authority 边界；`notifications` 允许普通 consumer 订阅全局通知；editor surfaces 尚未隔离为 Experimental；owner helper 仍可经 `symbols.original` 解包取得；manifest、validator、website 与 public root 继续存在身份、权限和稳定性矛盾。
 
 因此采用两级门禁：
 
@@ -47,53 +49,63 @@ PR #77 已形成四条可保留的纵向切片：
 | --- | --- | --- | --- | --- | --- |
 | `BlueUiNode` wire | `packages/api/src/contracts.ts` 中闭合 union；纯 clone/freeze；callback 与 signal 仍为 process-local | KEEP | renderer-neutral canonical tree；文档明确“数据可检查”不等于整个 contribution 可跨进程序列化 | api owns wire | V1：hostile realm/getter/cycle/depth/node/collection corpus；外部 tarball consumer |
 | `@dsh-blue/blue-ui` builders | 纯 builder、caller-safe，官方 panel/dialog/status 已消费 | KEEP | 只做 ergonomics，不另立 wire truth；输出必须通过同一 validator | ui package | V1：builder/wire/API declaration diff；至少两个外部插件共用 |
-| core validator/compiler | core 是唯一 admission/compiler 和 pi-tui boundary；已有 exhaustive/width tests | KEEP | 非 core 包不接触 pi-tui、ANSI、terminal width/focus；compiler failure 隔离 contribution | core | V1：2..120 width/hostile node；public kit packed import |
-| `panes` | host registry、每插件配额、buffer/replay、surface bridge、semantic events、responsive layout 已实现 | KEEP | Stable managed surface；明确 renderer owner 暂未 attach 时的 retained queue/replay | core surface owner | V1：header/right/bottom、narrow、owner unload/reload、focus restore、late event、20/40/80/120 packed fixture |
-| `overlays` | one-shot gesture、capturing 配额、FIFO/latest-wins、abort/close/focus restore 已实现 | KEEP | Stable managed overlay；普通插件不能主动开 capturing overlay | core overlay owner | V1：gesture expiry、double submit、unload、owner swap、timeout、hostile sibling |
+| core validator/compiler | core 是唯一 admission/compiler 和 pi-tui boundary；已有 exhaustive/width tests；`082c801` 已删除 legacy frontend renderer | KEEP | 非 core 包不接触 pi-tui、ANSI、terminal width/focus；compiler failure 隔离 contribution | core | V1：2..120 width/hostile node；public kit packed import；禁止恢复第二 renderer path |
+| `panes` | host registry、每插件配额、buffer/replay、surface bridge、semantic events、responsive layout已实现；仓内 packed examples 覆盖 header/right/bottom、20/40/80/120、absent/admission/unload | KEEP | Stable managed surface；明确 renderer owner 暂未 attach 时的 retained queue/replay | core surface owner | V1：在真实 surface manager 补 narrow、owner reload、focus restore、late event；独立生态 packed consumer |
+| `overlays` | one-shot gesture、capturing 配额、FIFO/latest-wins、abort/close/focus restore 已实现；仓内 packed example 覆盖 atomic capability rejection、gesture、unload/late use | KEEP | Stable managed overlay；普通插件不能主动开 capturing overlay | core overlay owner | V1：真实 renderer 的 focus/timeout/double submit/owner swap、hostile sibling；独立生态 packed consumer |
 | additive `status` | narrow recursive status node、独立 revision、transcript owner/compiler 已实现 | KEEP | Stable additive status；非交互、不能夺取 footer composition | transcript status owner | V1：external status packed fixture、width、render throw、unload/reload |
-| `status.provider` | inert candidates、settings selection、dry render、same-session LKG、cross-session default、3/60s breaker、fallback 已实现 | CHANGE | 保留 provider 事务；专用 snapshot 不隐式带 session id/cwd/model；需要时显式申请 `session.read` resource；加入 session epoch/revision | transcript composition + settings | V1：owner absent、theme/session switch、stale generation、selection persistence、failure attribution、真实 profile swap |
+| `status.provider` | inert candidates、settings selection、dry render、same-session LKG、cross-session default、3/60s breaker、fallback 已实现；仓内 packed candidate 的 13/13 双线证据来自 `b5f3310` checkpoint，只验证 admission/width/unload | CHANGE | 保留 provider 事务；专用 snapshot 不隐式带 session id/cwd/model；需要时显式申请 `session.read` resource；加入 session epoch/revision | transcript composition + settings | V1：final-head packed rerun、owner absent、theme/session switch、stale generation、selection persistence、failure attribution、真实 profile swap；dsh-status-bar 外部 slice |
 | `commands` | interaction bridge 映射到 Harness commands，具备 AbortSignal、owner-minted gesture、duplicate rollback、unload | KEEP | 只承诺 Blue-local UI command；能直接注册 Harness command 的 domain 插件继续走 host service | interaction owner | V1：packed command、late settlement/unload、gesture chain；文档避免双 command discovery |
-| `notifications` | 一个 capability 同时返回 publish/subscribe；owner bridge 使用全局 observer | CHANGE | public 只保留 `notifications.publish`；observe 属 owner control plane；定义 dedupe/replace/duration/priority 和动态 rate limit | notification model + interaction renderer | V1：publisher 隔离、普通插件不能观察其他插件、sink absent、rate/dedupe、unload/late publish |
-| `editor.extensions` | `5a24f54` 后已有真实 owner：passive node admission、`/ @ #` completion、action gesture、submit transform、revision/abort/unload 和 packed fixture | KEEP + CHANGE | Beta 保留完整纵向实现；v1 capability 拆为 decorations、completions、draft.read、draft.write、submit.transform，均为 Experimental/optional | interaction editor owner | BETA-MERGE：不得称 Stable；`before/after` 静态 `BlueUiNode` 与 runtime passive subset 收窄一致。V1：逐项最小授权；真实 editor input/completion apply/submit profile 路径；draft/history/IME 不丢 |
-| `editor.provider` | public type、registry 和 shell validator 存在；默认 bundle 没有 selection/swap owner，`open()` 返回 absent | REMOVE (Stable) | 不进入 v1 manifest/root；待完整 capture/abort/dispose/activate/restore 和第二个真实 provider 后另行提案 | future interaction/core owner | BETA-MERGE：从 Stable capability 声明移除或明确 Deferred。未来：draft/history/mode/attachments/focus/IME、failure rollback、unload |
+| `notifications` | 一个 capability 同时返回 publish/subscribe；任一普通 consumer 可收到其他插件 publish 的全局通知，owner bridge 另有 observer | CHANGE | public 只保留 `notifications.publish`；observe 属 owner control plane；定义 dedupe/replace/duration/priority 和动态 rate limit | notification model + interaction renderer | **BETA-MERGE blocker**：无条件移除普通 consumer subscribe并将 owner observe收回受 authority 保护的 control plane，不能靠降为 Experimental 保留越权观察。V1：publisher 隔离、sink absent、rate/dedupe、unload/late publish |
+| `editor.extensions` | `5a24f54` 后已有真实 owner：passive node/action、`/ @ #` completion、submit transform、revision/abort/unload；9/9 双线 packed 证据来自 `03cb7e0` checkpoint；当前不提供 draft read/write | KEEP + CHANGE | Beta 保留纵向实现；v1 将现有 decorations/completions/submit.transform 拆权，并另增 draft.read/write，均为 Experimental/optional | interaction editor owner | BETA-MERGE：不得称 Stable且须 final-head packed rerun；`before/after` 静态 `BlueUiNode` 与 runtime passive subset 收窄一致。V1：逐项最小授权；真实 editor input/completion apply/submit profile 路径；draft/history/IME 不丢 |
+| `editor.provider` | `fe48004` 后已有真实 owner、persisted user selection、actual-width dry render、同一 editor/focus 上的原子 shell swap、LKG/breaker/default fallback、abort/stale/unload；仓内 packed candidate 存在；public type仍只有 `render/onEvent`，未冻结 activate/dispose 或无状态 shell lifecycle语义 | KEEP + CHANGE | 作为 Experimental optional 的 host-owned editor shell provider；恰好一个 `editor-control`，不授予 draft/cursor/history/IME/raw-key 或 engine ownership；mode 另走 `session.read` grant | interaction owner + core compiler | BETA-MERGE：flat manifest阶段退出 public Stable surface、保留 internal/reference runtime。Experimental 发布：optional schema/subpath、public lifecycle、final-head packed和统一 profile。未来 Stable：独立生态 provider等完整门禁 |
 | flat `capabilities[]` | required/optional、capability version、resource grant、form 均不可表达；`open()` all-or-nothing | CHANGE | 对象式 required/optional request；每项 `{name, version, resources?}`；返回 negotiated grants | api/schema + host | V1：positive/negative schema corpus；required fail、optional degrade、resource subset/denial、duplicate cross-group |
-| manifest identity | inline 字段多为 optional；分发文档要求 root JSON；quickstart 不生成 JSON；id/name/row 是否相等互相矛盾 | CHANGE | `package.json.blue.manifest` 唯一发现入口；id=package name；entry=exports subpath；Cordis name/row id 独立 | schema + installer | V1：packed package、exports/files、runtime import 同一 JSON、identity negative corpus |
+| manifest identity | 已有 `package.json.blue.manifest` pointer、root JSON、quickstart 和六个 packed examples；但 validator 仍硬找 root JSON，`entry` 写内部 `./lib/index.js`，源码在 `open()` 旁再手写 manifest，并要求 entry `name`=package | CHANGE | `package.json.blue.manifest` 唯一发现入口；id=package name；entry=exports subpath；Cordis name/row id 独立 | schema + installer | V1：packed package、exports/files、runtime import 同一 JSON、identity negative corpus |
 | `integrity` author field | manifest 接受作者提供的 tarball digest | REMOVE | integrity/source commit 放 installer receipt/lock，不能由被验证包自证 | installer | V1：安装 receipt 和 source pin fixture；schema 拒绝 author integrity |
 | semver admission | manifest 用字符正则；host 只用 `/^\^?1/` 近似 API major | CHANGE | 真实 semver range parse/intersection；API、product、Harness、Node、capability version 分离 | schema/runtime admission | V1：prerelease、union、upper bound、invalid range corpus |
-| `session.read` | manifest 有名字，host 明确 denied；`BlueSessionReader` 同时含 `current/subscribe/request`，snapshot 无 epoch/revision | CHANGE | 纯 readonly facet；按 identity/cwd/status/mode/model resource 裁剪；snapshot/subscription 带 epoch/revision | app + narrow harness adapter | V1：same-id new epoch、session switch、headless absence、bounded snapshot、no Agent/Session/write leakage |
-| `session.act` | manifest 有名字但永远 denied；未来若复用 `BlueSessionReader` 会让 read grant 获得 followup/steer/interrupt | REMOVE | v1 无通用 session write；按真实业务 action 或 `conversation.itemActions` 扩展点设计 | domain plugin owns action | BETA-MERGE：移出公开 vocabulary。V1：negative schema/API fixture |
-| owner helper root exports | api root 导出 attach/snapshot/subscribe/mint/close；官方 bridge 用 Cordis `symbols.original` 解包后调用 | CHANGE | public host 只有 version/open/data facets；control plane 要求 bundle composition 创建的 authority/lease，普通 sibling 无法获得 | bundle + api host | **BETA-MERGE blocker**：hostile sibling 证明 unwrap/self-attach/snapshot/mint/close 均失败；官方 owner reload 保持正常 |
+| `session.read` | `f375c13` 已拆出纯 readonly `current/subscribe` facade、真实 app owner、monotonic revision、clone/freeze、replay/owner-gap fencing；但完整 `blueSessionReader` 仍是任意 sibling可 inject 的 Cordis service，可绕过 fields grant | CHANGE | 保留 readonly seed，按 identity/cwd/status/mode/model resource 裁剪，并加入明确 `sessionEpoch`；raw source只对 authority owner可见 | app + narrow harness adapter | **BETA-MERGE blocker**：隐藏/authority-gate raw reader并加 hostile direct-inject fixture。V1：same-id new epoch、session switch、headless absence、bounded snapshot、resource denial、no Agent/Session/write leakage |
+| `session.act` | `f375c13` 已实现独立 requester、followup/steer/interrupt、host-wide FIFO、abort、session/owner/consumer/unload stale fencing和双 Harness 线 packed fixture；完整 `blueSessionRequester` 仍可被任意 sibling inject，same-id 仍只按 id 判断且无 gesture/resource policy | REMOVE | v1 无通用 session write；app内部 dispatcher不作为 plugin-facing service，业务写按真实 action 或 `conversation.itemActions` 扩展点设计 | domain plugin owns action | **BETA-MERGE blocker**：移出公开 vocabulary并隐藏/authority-gate raw requester，hostile sibling direct inject必须失败。V1：negative schema/API fixture |
+| owner helper root exports | api root 仍导出 attach/snapshot/subscribe/mint/close；guarded proxy 直接调用现已拒绝，但官方 bridge 继续用 Cordis `symbols.original` 解包，普通 sibling 可复制该路径 | CHANGE | public host 只有 version/open/data facets；control plane 要求 bundle composition 创建的 authority/lease，普通 sibling 无法获得 | bundle + api host | **BETA-MERGE blocker**：hostile sibling 证明 unwrap/self-attach/snapshot/mint/close 均失败；官方 owner reload 保持正常 |
 | aggregate owner snapshot | 一个 snapshot 同时含全部 capability contribution 与 revisions | CHANGE | owner subscription 按 capability/lease 窄化；owner 不能观察无关插件数据 | capability owners | BETA-MERGE：至少隔离公共 root。V1：per-owner subscription 和 cross-capability negative fixture |
 | `BluePluginDefinition.apply(api: unknown)` | public type 无 loader/runtime consumer | REMOVE | v1 使用真实 Cordis entry + parsed manifest + negotiated typed API；不保留占位符 | api/loader | BETA-MERGE 或首个 schema PR 删除；compile negative fixture |
 | error taxonomy | stale/timeout/unavailable/resource denial 不可区分，多处压入 `BLUE_ACTION_REJECTED/ABORTED` | CHANGE | 采用目标契约的 negotiation/admission/execution 错误分类；无异常跨边界 | api | V1：每个 code 有可复现 fixture，message 不承担机器语义 |
-| legacy `dock` | public validator 拒绝，但 `BlueHostManifest`、host aggregate、transcript bridge和 bundle e2e 仍消费 | REMOVE | 官方 bottom surfaces 迁到 `panes` 后物理删除 type/registry/snapshot/bridge；旧 manifest 给明确迁移诊断 | transcript/core panes | V1：`rg` 无 public/internal dock compatibility；bundle e2e 改走 bottom pane |
+| legacy `dock` | `bbbe6b1` 已物理删除 type、registry、host aggregate、transcript bridge和 bundle consumer；validator 只保留 actionable migration diagnostic | REMOVE (CLOSED) | 保持 runtime 无 dock；旧 manifest 只返回明确迁移诊断 | transcript/core panes | Beta 代码门已关闭。V1：schema negative corpus 与 `rg` drift guard 防止兼容路径回流 |
 | legacy `panels/editor/tools` | migration validator 仍识别这些旧名字；无 v1 owner/API | REMOVE | 不进入新 schema、catalog 或 API root；validator 只返回明确迁移诊断 | schema/validator | V1：negative corpus；网站不再把旧名字描述为 future capability |
-| `projections.read` | app 内部 reader 可按任意字符串返回 `unknown`，没有 public resource gate | ADD | manifest 精确 key allowlist；一致 cut、size bound、epoch/asOfSeq、key unload 语义 | app/harness adapter | V1：dsh-context + Cost Meter，replay/resume、duplicate/older seq、key unload、late callback |
+| `projections.read` | `blueSessionProjections` app reader可按任意字符串返回 `unknown`，且仍是任意 sibling可 inject 的 Cordis service，没有 public resource gate | ADD | raw source只对 authority owner可见；manifest 精确 key allowlist；一致 cut、size bound、epoch/asOfSeq、key unload 语义 | app/harness adapter | **BETA-MERGE blocker**：隐藏/authority-gate raw projection reader并加 hostile direct-inject fixture。V1：dsh-context + Cost Meter，replay/resume、duplicate/older seq、key unload、late callback |
 | conversation APIs | conversation projection存在，但无 public bounded reader、navigate 或 item action registry | ADD | `conversation.read/navigate/itemActions`；item action 只调度，业务执行留在插件 service | conversation + transcript/interaction | V1：Navigator、Rewind、Message Edit、Bookmark/Tag reference；pagination/stale/gesture/unload |
 | `theme.provider` | frontend theme model存在；公开插件没有 provider negotiation/selection contract | ADD | semantic token candidate、用户选择、validation、fallback；无 ANSI/CSS | frontend/core composition | V1：Catppuccin，token completeness、swap failure、unload、narrow/width |
 | `settings.sections` | Blue 有内部 settings panel 和 dsh-settings owner；无第三方 section contract | ADD | 只贡献 settings UI；plugin config/schema/persistence 直接 inject `dsh-settings` | interaction settings UI | V1：Catppuccin + Lark，read-only backend、conflict、unload；证明无 Blue storage |
 | JSON Schema / TS manifest | 没有独立 schema；script 只检查字段存在且不复用 runtime validator | ADD | Draft 2020-12 schema 为源，生成 TS type；Ajv/validator/installer/runtime 共用；drift gate | api/schema | V1：schema corpus、generated diff、published URL/subpath、真实 tarball |
 | public API plane | owner helpers、Stable/Experimental、plugin-facing types混在 root | CHANGE | root 只导出 Stable；Experimental 走明确 subpath/标记；owner authority 不可由普通插件取得 | api package | BETA-MERGE：稳定性声明收窄。V1：API declaration report、exports/files/tsdown triangle |
-| docs/skills | website manifest/quickstart/seams、package README、skills 和代码 capability 状态漂移 | CHANGE | contract 是目标真相；package AGENTS 是当前实现；能力表从 schema/catalog 校验生成；中英同步 | docs + package owners | BETA-MERGE：不得把 absent/denied 写成 Stable。V1：docs build、parity、examples packed install、skill eval |
-| `BLUE_API_VERSION` | root与host已经声明 `1.0.0` | CHANGE | #77 只作为 `1.0.0-beta.1` 合并；全部 V1 gate 通过后一次性升 `1.0.0` | api/release | **BETA-MERGE blocker**：不产生错误稳定承诺；V1 release report |
+| docs/skills | website/README/skills 已补实际 session/editor owner 和示例，但把 flat manifest、`session.act`、editor surfaces 与 owner helpers一并描述成 Stable 1.0 | CHANGE | contract 是目标真相；package AGENTS 是当前实现；能力表从 schema/catalog 校验生成；中英同步 | docs + package owners | **BETA-MERGE blocker**：按 Stable/Experimental/Rejected 重写，不把“已实现”当“已冻结”。V1：docs build、parity、examples packed install、skill eval |
+| `BLUE_API_VERSION` | root与host仍声明 `1.0.0`；examples、README、website 和 rc.1 release note均按 `^1.0.0`/Stable 推广 | CHANGE | #77 只作为 `1.0.0-beta.1` 合并；全部 V1 gate 通过后一次性升 `1.0.0` | api/release | **BETA-MERGE blocker**：不产生错误稳定承诺；V1 release report |
 
 ## 3. 相关 PR 处置
 
 - PR [#72](https://github.com/dsh-blue/blue/pull/72) 与 #77 修改同一 UI 蓝图和索引，但保留了更旧的 API version、overlay/event 和实施裁决。它 MUST 关闭为被 #77 supersede，不能再单独合并。
 - PR [#76](https://github.com/dsh-blue/blue/pull/76) 文件上可独立处理，但 capability 调研仍基于旧四能力和 `dock`。若合并，MUST 标成带日期的需求快照或先按 #77 更新；它不是规范来源。
-- `docs/blue-ui-component-enhancement.md` 在 #77 中既有目标蓝图也有已经过期的“尚未实现”进度。Beta 合并前先修正事实；待本矩阵接管进度且真人验收完成后，再单独归档。
+- `docs/blue-ui-component-enhancement.md` 顶部仍称“产品实现尚未开始”，W5 段仍把已完成工作写成 future，而 W6 段又记录 W6-1..4 完成。Beta 合并前先消除这组内部矛盾；待本矩阵接管进度且真人验收完成后，再单独归档。
+- #77 的 PR body 仍停在“只到 W3/G3”、177 files/2730 tests/check:lib 69 和旧 G3 acceptance；它 MUST 更新到当前 head、W4-W6 scope、实际门禁与仍缺的最终验收。G3 acceptance 早于 W4-W6，不能覆盖其后的全部实现提交。
 
 ## 4. #77 Beta 合并前顺序
 
 以下工作保持在 #77 分支，完成后它才适合作为 Beta UI foundation 合并：
 
-1. **冻结新基线**：合入本契约文档，更新 PR 描述到 `03cb7e0` 或当时最新 head，列出 Stable/Experimental/Deferred 实际状态。
-2. **降级版本承诺**：`BLUE_API_VERSION` 与 host version 改为 `1.0.0-beta.1`；`^1.0.0` 示例不得声称当前可用。
-3. **隔离 control plane**：从 plugin-facing root 移除 owner helper；引入 composition authority/lease，禁止 `symbols.original` 成为 sibling 权限升级。
-4. **收窄公开 vocabulary**：删除 `session.act` 和 Stable `editor.provider`；`session.read` 在 owner 落地前不得伪装可用；editor extensions 标 Experimental。
-5. **保持成熟纵向切片**：canonical UI、panes/overlays、status、status provider、editor runtime 不回退；所有现有 unit/packed/width 证据继续绿。Editor packed fixture 已证明 host binding、replay、abort 和 unload，但 profile dogfood 还要穿过真实 input、completion apply 与 submit barrier。
-6. **修正文档事实**：package README/AGENTS 与 website 只能描述实际 owner；未实现目标链接到本文和 roadmap。
-7. **完整 worktree 验收**：全门禁、专用 profile dogfood、用户 live-test；未明确“验收通过”前不合并 #77。
+1. **OPEN - 冻结新基线**：合入本契约文档，把 PR 描述更新到 `c9e1600` 或当时最新 head，列出 Stable/Experimental/Rejected 实际状态和 W4-W6 scope。
+2. **OPEN - 降级版本承诺**：`BLUE_API_VERSION` 与 host version 改为 `1.0.0-beta.1`；`^1.0.0` 示例、package README、website 和 rc.1 release note不得声称当前已经 Stable 1.0。
+3. **OPEN - 隔离 control plane**：从 plugin-facing root 移除 owner helper；引入 composition authority/lease，禁止 `symbols.original` 成为 sibling 权限升级；aggregate/notification subscription 按 owner capability 窄化。
+4. **OPEN - 收窄公开 vocabulary**：移除 generic `session.act`，隐藏或 authority-gate可直接 inject 的 raw session/projection reader与 requester；保留 negotiated readonly `session.read` seed但不把无 resource/epoch 的形状称为 v1 Stable。当前 flat manifest不能表达 optional，因此 `editor.extensions` 和 `editor.provider` 先退出 public Beta manifest、仅保留 bundle-internal/reference runtime；R2/R3 negotiated optional plane落地后再以 Experimental 公开，不能只改标签继续暴露。
+5. **OPEN - 拆分 notifications**：public consumer 只保留 publish；普通 sibling 不能订阅其他插件通知，owner observe 进入受 authority 保护的 control plane。
+6. **DONE foundation - 保持成熟实现**：canonical UI、panes/overlays、status/status provider、editor extension/provider、split session facade、consumer lifetime fencing、dock/view 删除和 packed examples不回退。后续权限收敛必须保住现有 unit/width/lifecycle 证据。
+7. **OPEN - 修正文档事实**：package README/AGENTS 与 website区分“已实现 Beta”与“已冻结 Stable”；目标能力链接到 contract/roadmap。
+8. **OPEN - 完整 worktree 验收**：在收敛后的 final head重跑全门禁、相关 packed 双线 fixture、`smoke:pty` 和统一专用 profile；profile 穿过 default、120/80/40、pane/overlay、status/editor provider、theme/session swap、editor input/completion/submit 与 unload/reload。用户明确 live-test 验收前不合并 #77。
+
+### 当前自动证据
+
+`c9e1600` 的 GitHub CI 与 website check 为 green。W6-4 final-head 报告记录 184 files / 2915 tests passed / 31 个既有条件性 unit skips、per-file 100% coverage、check:lib 87、check:pack 11 tarballs；CI 还执行 frozen install、typecheck、lint、diagrams、build、`check:examples` 和 `smoke:happy`，但不直接执行全部 package fixture 双线。
+
+Packed evidence 包括 final-head examples 在 Harness `0.1.1-rc.2` / `0.1.1-rc.1` 各 7/7；W6-4 final-head 手工报告中的 `@dsh-blue/blue-app` package fixture 两条 Harness line 各 9/9（其中含 `session.read`、`session.act` 两个专用场景）、context/remote 各 7/7、OpenPencil/Lark 各 9/9，均无 fixture skip/failure且 cleanup 完成。Status provider 13/13、editor extensions 9/9 和 editor provider 11/11 的双线结果分别来自 `b5f3310`、`03cb7e0`、`14cbbb7` checkpoint，权限/稳定性修改后仍须在最终 head重跑。仓内 examples 证明 public tarball/host peer closure 和部分 lifecycle/width，不具备 `form`、required/optional/resource negotiation，也不是独立生态包，不能关闭 v1 三形态或外部消费者门禁。
+
+CI 的 `smoke:happy` 不替代 final-head `smoke:pty`、统一 W4-W6 profile 或人工验收。旧 `blue-ui-g3` 验收早于 W4-W6，不能覆盖其后的全部实现提交，也不能作为当前 head 的 merge acceptance。
 
 这一步不要求把整个 v1 roadmap 塞回 #77。manifest/schema 和新 ecosystem capability 在 master 上用后续小 PR 收敛，避免 #77 继续膨胀。
 
@@ -103,10 +115,10 @@ PR #77 已形成四条可保留的纵向切片：
 Beta merge
   -> JSON Schema + identity + semver + generated manifest type
   -> negotiated grants + public/control plane + error taxonomy
-  -> existing UI surface cleanup (notifications split, dock removal)
-  -> session/projection/conversation owners
+  -> existing UI surface cleanup (notifications split, status snapshot; dock 已完成)
+  -> session.read resource/epoch + projection/conversation owners
   -> theme/settings owners
-  -> editor Experimental split
+  -> editor Experimental split + provider namespace
   -> synthetic + ecosystem packed fixtures
   -> skills + bilingual docs
   -> 1.0.0 release gate


### PR DESCRIPTION
## Summary

This is a docs-only design and delivery-control PR. It does not release a plugin runtime or Plugin API v1.

It establishes four separate sources of truth:

- `docs/blue-plugin-contract-v1.md`: Draft API v1 design source
- `docs/blue-plugin-host-lifecycle.md`: internal authority, generation, owner-gap, restore, and stale behavior
- `docs/blue-pr77-convergence-matrix.md`: PR #79 boundary, PR #77 merge runbook, and the P1-P9 follow-up PR queue
- `docs/blue-plugin-api-v1-roadmap.md`: R0-R6 phase dependencies and final release gates

`docs/README.md` and the root `AGENTS.md` point readers and coding agents at the correct current/target/execution source.

## Frozen design decisions

- The v1 target has seven Stable capabilities: `commands`, `status`, `panes`, `overlays`, `notifications.publish`, `session.read`, and `session.projections.read`.
- `package.json.blue.manifest` remains the discovery pointer.
- The runtime manifest has no `form`; `integrated`, `adapter`, and `pure-ui` are migration descriptions only.
- Blue product packages remain on a lockstep `0.x` line while the plugin protocol is independently versioned.
- Generic public `session.act`, raw Agent/Session access, owner control helpers, and global notification observation are rejected.
- PR #77 absorbs the relevant PR #72 design input; PR #72 is not an independent merge prerequisite.

## PR #79 publication boundary

Merging this PR publishes only Draft/Active repository documents and the root authority pointer. It does not:

- modify runtime, packages, schema, generated types, validator, installer, examples, presets, skills, bundle composition, or `website/`
- publish npm artifacts, dist-tags, GitHub Releases, protocol tags, or product/protocol mappings
- claim that v1 quickstarts or Stable capabilities are available
- contact ecosystem authors, open invitation Issues, submit upstream code PRs, or contact dsh-market

Website developer docs, the two skills, and Creative Mode persistent-package authoring are later independent deliveries after an executable Beta schema/catalog exists.

## PR #77 merge runbook

Audit facts used by the handbook:

- `master@1d0f01eb914356dd5a179faaddaa9a205dae33b3`
- PR #77 audit head `9a6a255`
- previously accepted runtime candidate `cf8b3bd`

After this PR merges:

1. Update PR #77 onto the PR #79 merge commit and record its new base and exact head.
2. Keep the accepted compiler, managed panes/overlays, additive status, provider/editor reference runtime, lifetime fencing, and packed suite.
3. Mark API/host as `1.0.0-beta.1`; remove public `session.act`; make notifications publish-only; remove public owner controls; protect raw session/projection backing services; move provider/editor facets out of the Stable root.
4. Re-run hostile-sibling, owner reload, full repository gates, current/previous Harness packed fixtures, smoke, and dedicated worktree-profile evidence on the new exact head.
5. Require fresh human live acceptance for that exact head before merging PR #77.
6. Merge PR #77 only as a Beta foundation. Do not publish protocol `1.0.0` or a formal v1 developer manual in that merge.

The handbook explains `control-plane authority`, `owner generation`, and `owner gap` in observable terms. Definitions for commands, status, and panes may be restored after a UI owner reload; actions, notifications, overlays, gestures, and old callback results must never be replayed.

## Follow-up delivery queue

The merge handbook defines the ordered independent PR batches:

- P1: schema, generated manifest type, semantic validator, immutable exports, and product/protocol mapping
- P2: required/optional/resource admission, exact grants, errors, protected control plane, and generation behavior
- P3: UI capability Beta PRs
- P4: separate `session.read` and `session.projections.read` Beta PRs
- P5: author skill, Creative Mode prototype-to-local-package flow, and task-oriented bilingual developer manual
- P6: six equally treated ecosystem validation projects and the maintainer outreach skill
- P7: per-capability Stable promotion
- P8: dsh-market Beta cooperation after Public Beta, the author skill, and at least two runnable integrations
- P9: protocol `1.0.0` and corresponding Blue `0.x` artifacts

Every follow-up PR records scope, authority, fallback, lifecycle, artifacts, exact evidence, human acceptance, and the precise release claim it closes.

## Verification

- `git diff --check`
- `pnpm run diagrams:check`
- file-boundary and rejected-terminology scans

No Website build or runtime profile was used as PR #79 evidence because this PR changes neither Website source nor runtime behavior. PR #79 should be reviewed and merged as the control document used to converge PR #77 and the later independent PRs.