### PR TITLE
chore(bundle): add npm keywords to @dsh-blue/blue

### DIFF
--- a/packages/bundle/blue/package.json
+++ b/packages/bundle/blue/package.json
@@ -1,6 +1,20 @@
 {
   "name": "@dsh-blue/blue",
   "description": "The dsh Blue bundle: the interactive terminal UI profile over dsh-base",
+  "keywords": [
+    "dsh",
+    "deepseek-harness",
+    "dsh-plugin",
+    "blue",
+    "tui",
+    "terminal",
+    "terminal-ui",
+    "cordis",
+    "pi-tui",
+    "coding-agent",
+    "ai-agent",
+    "plugin"
+  ],
   "version": "0.1.2-alpha.1",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Why

Community index sites (findharness.com, deepseekharness.io) and npm search discover dsh plugins by keyword. `@dsh-blue/blue-cli` already ships keywords, but the main bundle package `@dsh-blue/blue` — the one `dsh plugin add @dsh-blue/blue@rc` installs — has none, so it stays invisible to keyword-driven discovery.

## What

Add 12 keywords to `packages/bundle/blue/package.json`, mirroring the cli package's set plus TUI-specific ones (`tui`, `terminal`, `cordis`, `pi-tui`, `plugin`).

No code changes; keywords surface on the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)