### PR TITLE
fix(plugin-kit): derive conformance Cordis peer

### DIFF
--- a/packages/plugin-kit/AGENTS.md
+++ b/packages/plugin-kit/AGENTS.md
@@ -17,12 +17,15 @@ compatibility entries. Validation is static and script-disabled packing is
 mandatory. Conformance uses a throwaway npm project, normal peer resolution,
 the exact lines listed by `supportedHarnessLines`, native ESM exports, and
 always reports cleanup. `0.1.2-alpha.1` lists only Harness `0.1.2-alpha.2`;
-no RC line is implied or tested. Neither command is a security sandbox.
+no RC line is implied or tested. Its external fixture derives the host Cordis
+range from the installed Blue API package instead of carrying a second pin.
+Neither command is a security sandbox.
 
 The generator refuses a non-empty destination and never creates a repository,
 commit, tag, profile installation, or npm release. Keep `README.md` and
 `README.zh.md` synchronized. Changes to the bin update package files/build
 claims, installed-tarball author fixture, author skill evals, tutorial packed
 fixtures, and this file together. `script/check-pack.mjs` installs the packed
-API/UI/kit artifacts in a throwaway npm project and executes the installed bin,
-so source-checkout success alone is insufficient.
+API/UI/frontend/core/kit artifacts in a throwaway npm project and executes the
+installed bin through create, validate, and conformance, so source-checkout
+success alone is insufficient.

--- a/packages/plugin-kit/runtime/conformance.mjs
+++ b/packages/plugin-kit/runtime/conformance.mjs
@@ -9,8 +9,9 @@
 import { execFileSync, spawnSync } from 'node:child_process'
 import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
 import { mkdtemp, rm } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
-import { join, relative, resolve, sep } from 'node:path'
+import { dirname, join, relative, resolve, sep } from 'node:path'
 import { createPackageImporter } from './import-from-directory.mjs'
 import { packWithoutScripts } from './pack-without-scripts.mjs'
 import { collectLocalPackageClosure, summarizeHarnessPackageInstances } from './plugin-fixture-contract.mjs'
@@ -18,6 +19,7 @@ const repositoryCandidate = resolve(import.meta.dirname, '../../..')
 const repositoryRoot = existsSync(join(repositoryCandidate, 'packages', 'api', 'package.json'))
   ? repositoryCandidate
   : undefined
+const runtimeRequire = createRequire(import.meta.url)
 const pinnedHarnessLine = '0.1.2-alpha.2'
 const argumentsList = process.argv.slice(2)
 let packageArgument = '.'
@@ -199,13 +201,30 @@ try {
   const dependencies = Object.fromEntries([...packages].map(([name, tarball]) => [name, `file:${tarball}`]))
   if (repositoryRoot === undefined) {
     const kitManifest = JSON.parse(readFileSync(resolve(import.meta.dirname, '../package.json'), 'utf8'))
+    const apiManifestPath = runtimeRequire.resolve('@dsh-blue/blue-api/package.json')
+    const apiManifest = JSON.parse(readFileSync(apiManifestPath, 'utf8'))
+    const cordisRange = apiManifest.peerDependencies?.['@deepseek-ai/cordis']
+    ensure(typeof cordisRange === 'string' && cordisRange !== '', 'FIXTURE_BLUE_API_HOST_PEER_MISSING', '@dsh-blue/blue-api has no Cordis peer range')
+    const installedBlueManifests = new Map([['@dsh-blue/blue-api', apiManifestPath]])
+    for (const name of [
+      '@dsh-blue/blue-ui',
+      '@dsh-blue/blue-frontend',
+      '@dsh-blue/blue-core',
+    ]) {
+      try { installedBlueManifests.set(name, runtimeRequire.resolve(`${name}/package.json`)) } catch {}
+    }
     for (const name of [
       '@dsh-blue/blue-api',
       '@dsh-blue/blue-ui',
       '@dsh-blue/blue-frontend',
       '@dsh-blue/blue-core',
-    ]) dependencies[name] ??= kitManifest.version
-    dependencies['@deepseek-ai/cordis'] ??= '4.0.1'
+    ]) {
+      const installedManifest = installedBlueManifests.get(name)
+      dependencies[name] ??= installedManifest === undefined
+        ? kitManifest.version
+        : `file:${pack(dirname(installedManifest), false)}`
+    }
+    dependencies['@deepseek-ai/cordis'] ??= cordisRange
     dependencies['@deepseek-ai/dsh-invariants'] ??= requestedHarnessLine
   }
   const harnessPackageNames = new Set()

--- a/packages/transcript/tests/version.spec.ts
+++ b/packages/transcript/tests/version.spec.ts
@@ -199,6 +199,9 @@ describe('the harness dependency line', () => {
     expect(source).toContain('BLUE_PLUGIN_SUPPORTED_HARNESS_LINES = [BLUE_PLUGIN_HARNESS_LINE]')
     const fixture = readFileSync(new URL('../../plugin-kit/runtime/conformance.mjs', import.meta.url), 'utf8')
     expect(fixture).toContain(`const pinnedHarnessLine = '${HARNESS_LINE}'`)
+    expect(fixture).toContain("runtimeRequire.resolve('@dsh-blue/blue-api/package.json')")
+    expect(fixture).toContain("apiManifest.peerDependencies?.['@deepseek-ai/cordis']")
+    expect(fixture).not.toMatch(/dependencies\['@deepseek-ai\/cordis'\] \?\?= '\d/u)
   })
 
   it('ci.yml derives the CLI pin from HARNESS_LINE, not a literal', () => {

--- a/script/check-pack.mjs
+++ b/script/check-pack.mjs
@@ -178,9 +178,9 @@ void node
   }
 }
 
-function verifyPluginKit(apiTarball, uiTarball, kitTarball) {
-  if (apiTarball === undefined || uiTarball === undefined || kitTarball === undefined) {
-    fail('plugin author kit fixture requires packed API, UI, and plugin-kit tarballs')
+function verifyPluginKit(apiTarball, uiTarball, frontendTarball, coreTarball, kitTarball) {
+  if ([apiTarball, uiTarball, frontendTarball, coreTarball, kitTarball].includes(undefined)) {
+    fail('plugin author kit fixture requires packed API, UI, frontend, core, and plugin-kit tarballs')
     return
   }
   const fixtureRoot = mkdtempSync(join(tmpdir(), 'blue-plugin-kit-pack-'))
@@ -191,6 +191,8 @@ function verifyPluginKit(apiTarball, uiTarball, kitTarball) {
       dependencies: {
         '@dsh-blue/blue-api': `file:${apiTarball}`,
         '@dsh-blue/blue-ui': `file:${uiTarball}`,
+        '@dsh-blue/blue-frontend': `file:${frontendTarball}`,
+        '@dsh-blue/blue-core': `file:${coreTarball}`,
         '@dsh-blue/blue-plugin-kit': `file:${kitTarball}`,
       },
     }, null, 2)}\n`)
@@ -206,7 +208,17 @@ function verifyPluginKit(apiTarball, uiTarball, kitTarball) {
     if (validation.valid !== true || validation.package !== '@blue-pack-fixture/tutorial') {
       throw new Error('installed bin did not create and validate its package')
     }
-    console.log('plugin author kit: packed install, catalog, create, and validate passed')
+    const conformance = JSON.parse(execFileSync(bin, ['conformance', pluginRoot], {
+      cwd: fixtureRoot,
+      encoding: 'utf8',
+      timeout: 240_000,
+    }))
+    if (conformance.valid !== true || conformance.installed !== true || conformance.peerResolution !== 'normal' ||
+        conformance.skipped?.length !== 0 || conformance.failures?.length !== 0 ||
+        !isDeepStrictEqual(conformance.declared, conformance.executed)) {
+      throw new Error(`installed bin conformance failed: ${JSON.stringify(conformance)}`)
+    }
+    console.log('plugin author kit: packed install, catalog, create, validate, and conformance passed')
   } catch (error) {
     fail(`plugin author kit fixture failed: ${error instanceof Error ? error.message : String(error)}`)
   } finally {
@@ -262,6 +274,8 @@ verifyExternalUiKit(tarballs.get('@dsh-blue/blue-api'), tarballs.get('@dsh-blue/
 verifyPluginKit(
   tarballs.get('@dsh-blue/blue-api'),
   tarballs.get('@dsh-blue/blue-ui'),
+  tarballs.get('@dsh-blue/blue-frontend'),
+  tarballs.get('@dsh-blue/blue-core'),
   tarballs.get('@dsh-blue/blue-plugin-kit'),
 )
 


### PR DESCRIPTION
## Summary

- derive the external conformance fixture Cordis range from the installed Blue API peer contract instead of pinning 4.0.1
- reuse locally installed packed Blue packages when available so prerelease conformance does not depend on already-published Blue artifacts
- extend the installed plugin-kit pack gate through create, validate, and conformance, with a drift regression assertion

## Impact

This fixes the npm ERESOLVE that blocks plugin-kit conformance for Blue 0.1.2-alpha.1 / Harness 0.1.2-alpha.2. It does not change installed Blue runtime behavior. Because 0.1.2-alpha.1 is already published, users need a newly published plugin-kit release to receive the fix.

## Verification

- pnpm run verify:full
- node script/check-pack.mjs
- focused version drift test (13 passed)
- packed installed CLI conformance completed with normal peer resolution and no skipped or failed scenarios
