### PR TITLE
fix(ci): emit website check for every PR

### DIFF
--- a/.github/workflows/website-pages.yml
+++ b/.github/workflows/website-pages.yml
@@ -14,14 +14,9 @@ on:
       - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
+  # Branch protection requires Build check (PR) for every pull request, so
+  # this event must not be path-filtered.
   pull_request:
-    paths:
-      - .github/workflows/website-pages.yml
-      - website/**
-      - script/marketplace-fetch.mjs
-      - package.json
-      - pnpm-lock.yaml
-      - pnpm-workspace.yaml
   # 保留每日重建节奏以同步收录仓数据；marketplace 仓 merge 后也会通过
   # workflow_dispatch 触发本流程（跨仓 PAT 触发，见收录指南）。
   schedule:


### PR DESCRIPTION
## Summary

- run the `website-pages` pull-request workflow without path filtering
- guarantee the globally required `Build check (PR)` context exists for every pull request
- keep push, schedule, and deployment path filters unchanged

## Why

Branch protection requires both `typecheck / lint / test (coverage)` and `Build check (PR)` with strict up-to-date enforcement. The pull-request workflow previously emitted the website context only for a narrow path set, leaving PRs such as #95 permanently blocked even when their applicable CI passed.

## Verification

- `git diff --check`
- `pnpm run verify:full`
- 196 test files; 3205 passed, 31 skipped
- 100% statements, branches, functions, and lines
- build/check:lib/authoring fixtures/happy smoke passed