### PR TITLE
fix(core): normalize enhanced navigation input

### DIFF
--- a/packages/core/src/terminal.ts
+++ b/packages/core/src/terminal.ts
@@ -10,6 +10,8 @@
 import {
   Container,
   HStack,
+  isKeyRelease,
+  parseKey,
   ProcessTerminal,
   ScrollView,
   TuiAltScreen,
@@ -39,10 +41,27 @@ interface BlueRuntimeOverlayOptions extends BlueOverlayOptions { readonly maxWid
 
 const KEY_UP = '\x1b[A'
 const KEY_DOWN = '\x1b[B'
+const KEY_LEFT = '\x1b[D'
+const KEY_RIGHT = '\x1b[C'
 const KEY_PAGE_UP = '\x1b[5~'
 const KEY_PAGE_DOWN = '\x1b[6~'
 const KEY_HOME = '\x1b[H'
 const KEY_END = '\x1b[F'
+const KEY_INSERT = '\x1b[2~'
+const KEY_DELETE = '\x1b[3~'
+
+const NORMALIZED_NAVIGATION_INPUT = new Map<string, string>([
+  ['up', KEY_UP],
+  ['down', KEY_DOWN],
+  ['left', KEY_LEFT],
+  ['right', KEY_RIGHT],
+  ['pageUp', KEY_PAGE_UP],
+  ['pageDown', KEY_PAGE_DOWN],
+  ['home', KEY_HOME],
+  ['end', KEY_END],
+  ['insert', KEY_INSERT],
+  ['delete', KEY_DELETE],
+])
 
 /** Renderer choice kept inside core's L0 boundary. */
 export type BlueScreenMode = 'main' | 'alternate'
@@ -226,6 +245,20 @@ export function normalizeWheelInput(data: string): string | undefined {
   if ((button & 64) === 0) return undefined
   const direction = button & 3
   return direction === 0 ? KEY_UP : direction === 1 ? KEY_DOWN : undefined
+}
+
+/**
+ * Normalize unmodified navigation events to the legacy sequences consumed by
+ * Blue's raw-key paths. Enhanced Kitty releases and modified navigation keep
+ * their original encoding so event-type and modifier semantics remain intact.
+ * @param data - one decoded terminal input sequence.
+ * @returns the canonical navigation sequence, or `undefined` when the input
+ *   must pass through unchanged.
+ */
+export function normalizeNavigationInput(data: string): string | undefined {
+  if (isKeyRelease(data)) return undefined
+  const key = parseKey(data)
+  return key === undefined ? undefined : NORMALIZED_NAVIGATION_INPUT.get(key)
 }
 
 /**
@@ -431,6 +464,13 @@ export async function startBlueTerminal(
     ? [...(current as unknown as { inputListeners: Set<TuiInputListener> }).inputListeners][0]
     : undefined
   if (viewportInput !== undefined) current.removeInputListener(viewportInput)
+  // Herdr forwards Kitty functional-key codepoints while tmux commonly emits
+  // legacy CSI forms. Canonicalize both before any Blue or viewport listener
+  // sees them so every raw-key path receives the same navigation vocabulary.
+  const removeNavigationNormalizer = current.addInputListener(data => {
+    const normalized = normalizeNavigationInput(data)
+    return normalized === undefined ? undefined : { data: normalized }
+  })
   // Track dock membership for contextual wheel routing. The editor's handler
   // consumes its own wheel reports; a focused replacement panel receives the
   // direction-key form, while an unfocused/empty tree keeps the raw report for
@@ -917,6 +957,7 @@ export async function startBlueTerminal(
         removeWheelNormalizer()
         removeViewportInput()
         removeContentScrollHandler()
+        removeNavigationNormalizer()
         outputRecovery?.deactivate()
         if (activeRuntime === runtime) activeRuntime = undefined
         return
@@ -929,6 +970,7 @@ export async function startBlueTerminal(
       removeWheelNormalizer()
       removeViewportInput()
       removeContentScrollHandler()
+      removeNavigationNormalizer()
       if (activeRuntime === runtime) activeRuntime = undefined
     },
   }

--- a/packages/core/tests/terminal.spec.ts
+++ b/packages/core/tests/terminal.spec.ts
@@ -13,7 +13,13 @@ import { LAYOUT_NODE, type LayoutNode } from '@earendil-works/pi-tui/dist/layout
 import { ui } from '../../ui/src/index.ts'
 import { compileBlueUiNode } from '../src/ui-compiler.ts'
 import type { BlueComponent, BlueComponents, BlueFocusable, BlueRgbColor, BlueSemanticColors } from '../src/types.ts'
-import { createStableTuiReference, createTerminalRelease, normalizeWheelInput, startBlueTerminal } from '../src/terminal.ts'
+import {
+  createStableTuiReference,
+  createTerminalRelease,
+  normalizeNavigationInput,
+  normalizeWheelInput,
+  startBlueTerminal,
+} from '../src/terminal.ts'
 import type { FrameOverflowEntry } from '../src/frame-clamp.ts'
 import type { AmbientOutputStream } from '../src/output-recovery.ts'
 import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from '../src/width.ts'
@@ -1259,7 +1265,7 @@ describe('alternate-screen runtime', () => {
     terminal.dispose()
   })
 
-  it('routes wheel and page keys to a focused replacement panel', async () => {
+  it('routes wheel and legacy or enhanced navigation keys to a focused replacement panel', async () => {
     const terminal = new FakeTerminal(40, 10)
     const runtime = await startBlueTerminal(terminal, noProbe, undefined, undefined, 'alternate')
     const received: string[] = []
@@ -1277,8 +1283,33 @@ describe('alternate-screen runtime', () => {
     terminal.sendInput('\x1b[B')
     terminal.sendInput('\x1b[<65;1;1M')
     terminal.sendInput('\x1b[6~')
+    terminal.sendInput('\x1b[57419;1:1u')
+    terminal.sendInput('\x1b[57420;1:1u')
+    terminal.sendInput('\x1b[57417;1:1u')
+    terminal.sendInput('\x1b[57418;1:1u')
+    terminal.sendInput('\x1b[57421;1:1u')
+    terminal.sendInput('\x1b[57422;1:1u')
+    terminal.sendInput('\x1b[57423;1:1u')
+    terminal.sendInput('\x1b[57424;1:1u')
+    terminal.sendInput('\x1b[57425;1:1u')
+    terminal.sendInput('\x1b[57426;1:1u')
 
-    expect(received).toEqual(['\x1b[A', '\x1b[B', '\x1b[B', '\x1b[6~'])
+    expect(received).toEqual([
+      '\x1b[A',
+      '\x1b[B',
+      '\x1b[B',
+      '\x1b[6~',
+      '\x1b[A',
+      '\x1b[B',
+      '\x1b[D',
+      '\x1b[C',
+      '\x1b[5~',
+      '\x1b[6~',
+      '\x1b[H',
+      '\x1b[F',
+      '\x1b[2~',
+      '\x1b[3~',
+    ])
     await runtime.stop()
   })
 
@@ -1597,6 +1628,34 @@ describe('overlay focus discipline', () => {
 })
 
 describe('input listeners on the stable reference', () => {
+  it('normalizes unmodified enhanced navigation press and repeat events', () => {
+    const enhanced = [
+      ['57419', '\x1b[A'],
+      ['57420', '\x1b[B'],
+      ['57417', '\x1b[D'],
+      ['57418', '\x1b[C'],
+      ['57421', '\x1b[5~'],
+      ['57422', '\x1b[6~'],
+      ['57423', '\x1b[H'],
+      ['57424', '\x1b[F'],
+      ['57425', '\x1b[2~'],
+      ['57426', '\x1b[3~'],
+    ] as const
+
+    for (const [codepoint, normalized] of enhanced) {
+      expect(normalizeNavigationInput(`\x1b[${codepoint};1:1u`)).toBe(normalized)
+      expect(normalizeNavigationInput(`\x1b[${codepoint};1:2u`)).toBe(normalized)
+    }
+  })
+
+  it('preserves enhanced navigation releases, modifiers, and unrelated input', () => {
+    expect(normalizeNavigationInput('\x1b[57419;1:3u')).toBeUndefined()
+    expect(normalizeNavigationInput('\x1b[57419;2:1u')).toBeUndefined()
+    expect(normalizeNavigationInput('\x1b[57417;5:1u')).toBeUndefined()
+    expect(normalizeNavigationInput('text')).toBeUndefined()
+    expect(normalizeNavigationInput('\x1b[99999;1:1u')).toBeUndefined()
+  })
+
   it('normalizes SGR and legacy wheel reports at the core input boundary', () => {
     expect(normalizeWheelInput('\x1b[<64;10;4M')).toBe('\x1b[A')
     expect(normalizeWheelInput('\x1b[<65;10;4M')).toBe('\x1b[B')

--- a/script/smoke-pty-output-recovery.mjs
+++ b/script/smoke-pty-output-recovery.mjs
@@ -1,7 +1,7 @@
 // Real-process regression for Host stdout/stderr bypassing the alternate-
 // screen renderer. A child preload logs a large JSON value after the turn has
-// settled; Blue must repaint the editor/footer cells, and Up must recover the
-// user's prompt rather than the out-of-band JSON.
+// settled; Blue must repaint the editor/footer cells, and Herdr's enhanced Up
+// sequence must recover the user's prompt rather than the out-of-band JSON.
 
 import { createRequire } from 'node:module'
 import { existsSync, readdirSync, chmodSync, statSync } from 'node:fs'
@@ -101,10 +101,10 @@ try {
   }
   if (!recovered.includes('deepseek-v4-flash')) throw new Error('footer was not restored')
 
-  term.write('\x1b[A')
+  term.write('\x1b[57419;1:1u')
   await sleep(250)
   const history = (await screen()).join('\n')
-  if (!history.includes('history prompt')) throw new Error('Up did not restore the user prompt')
+  if (!history.includes('history prompt')) throw new Error('enhanced Up did not restore the user prompt')
   if (history.includes('host-bleed-')) throw new Error('Host JSON entered editor history')
 
   term.write('\x03')


### PR DESCRIPTION
## Summary

- normalize unmodified Kitty functional navigation events at the core terminal boundary
- preserve modified navigation and key-release events unchanged
- cover all ten navigation keys and route Herdr input through a focused replacement panel
- exercise Herdr's enhanced Up sequence through the real PTY output-recovery smoke

## Root cause

Herdr forwards Kitty functional key codepoints such as `CSI 57419;1:1u`, while tmux commonly translates the same input to legacy CSI sequences. pi-tui parses both forms, but Blue's downstream viewport and panel paths still compare raw legacy bytes, so direct Herdr navigation was intercepted or ignored before `/model` and similar panels could act on it.

## Verification

- `pnpm run verify:full` (196 files; 3207 passed, 31 skipped; 100% statements/branches/functions/lines)
- `pnpm run smoke:pty:output` (`PTY_OUTPUT_RECOVERY_PASS exit=0` with `CSI 57419;1:1u`)

## Acceptance

Pending direct Herdr and tmux acceptance with the dedicated `blue-herdr-keys` profile. Keep this PR draft until that acceptance is complete.
